### PR TITLE
Copy content from old website in new structure

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,3 +1,19 @@
 title: About
 page_order: 4
 
+_Copied from <http://www.tdwg.org/about-tdwg/>_
+
+**Biodiversity Information Standards (TDWG)**, also known as the Taxonomic Databases Working Group, is a not for profit scientific and educational association that is affiliated with the International Union of Biological Sciences. 
+
+TDWG was formed to establish international collaboration among biological
+database projects. TDWG promoted the wider and more effective dissemination of
+information about the World's heritage of biological organisms for the benefit
+of the world at large. Biodiversity Information Standards (TDWG) now focuses
+on the development of standards for the **exchange** of
+biological/biodiversity data.
+
+## Our mission
+
+* Develop, adopt and promote standards and guidelines for the recording and exchange of data about organisms
+* Promote the use of standards through the most appropriate and effective means and
+* Act as a forum for discussion through holding meetings and through publications

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,3 +1,3 @@
 title: About
-page_order: 1
+page_order: 4
 

--- a/content/pages/about/committees.md
+++ b/content/pages/about/committees.md
@@ -1,2 +1,119 @@
 title: Executive committee
 page_order: 2
+
+_Copied from <http://www.tdwg.org/about-tdwg/executive/exec-comm-2017/>_
+
+The TDWG Executive is elected in the 3rd or 4th Quarter of the year. Nominations are opened before the annual meeting and voting by email is conducted during or shortly after the meeting. With adoption of the new Constitution (2016), officers will usually serve for two calendar years. In the transition year (2017), however, some officers will serve for only one year. This will move TDWG into a regular pattern that requires at most half of the Executive Committee to be re-elected and possibly replaced in a given year.
+
+[Full election results for the 2017 Executive Committee.](http://www.tdwg.org/about-tdwg/executive/exec-comm-2017/fileadmin/tdwg/about-tdwg/Election_Results_TDWG_Executive_Committee_2017.pdf)
+
+The [Roles and Responsibilities ](http://www.tdwg.org/about-tdwg/executive/exec-comm-2017/fileadmin/executive/TDWG_Executive_Committee_RolesAndResponsibilities.pdf)for the Executive Committee and Secretariat are set forth in the Constitution and supplemented by a document written during the [TDWG Infrastructure Project.](http://www.tdwg.org/about-tdwg/executive/exec-comm-2017/activities/tip/)
+
+## Core Officers
+
+### Chair
+
+Dimitris Koureas
+Natural History Museum, London, UNITED KINGDOM
+[d.koureas (at) nhm (dot) ac (dot) uk](mailto:d.koureas@nhm.ac.uk)
+
+### Deputy Chair
+
+James Macklin
+Agriculture and Agri-Food Canada,. Ottawa, Ontario, CANADA
+[james.macklin (at) agr (dot) gc (dot) ca](mailto:james.macklin@agr.gc.ca)
+
+### Secretary
+
+Quentin Groom
+Botanical Garden Meise, BELGIUM
+[secretary (at) tdwg (dot) org](mailto:secretary@tdwg.org)
+
+### Treasurer
+
+William Ulate
+Missouri Botanical Garden. St. Louis, MO, USA
+[treasurer (at) tdwg (dot) org](mailto:treasurer@tdwg.org)
+
+## Subcommittee Chairs
+
+### Technical Architecture Group, Chair
+
+Greg Whitbread
+Taxamatics, Canberra, ACT, AUSTRALIA
+[whitbread.greg (at) gmail (dot) com](mailto:whitbread.greg@gmail.com)
+
+### Fundraising and Partnerships Subcommittee, Chair
+
+Martin Kalfatovic
+Smithsonian Institution Libraries and Biodivesity Heritage Library, Washington DC, USA
+[martin (dot) kalfatovic (at) gmail (dot) com](mailto:martin.kalfatovic@gmail.com)
+
+### Infrastructure Subcommittee, Chair
+
+Tim Robertson
+Global Biodiversity Information Facility, Copenhagen, DENMARK
+[trobertson (at) gbif (dot) org](mailto:trobertson@gbif.org)
+
+### Outreach and Communications Subcommittee, Chair
+
+Prabhakar Rajagopal
+Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), Bangalore, INDIA
+[prabha.prabhakar (at) gmail (dot) com](mailto:prabha.prabhakar@gmail.com)
+
+### Time and Place Subcommittee, Chair
+
+Patricia Mergen
+Royal Museum for Central Africa and Botanic Garden Meise, BELGIUM
+[mergen.patricia (at) gmail (dot) com](mailto:mergen.patricia@gmail.com)
+
+## Regional Representatives
+
+### Africa
+
+Lucy Waruingi
+African Conservation Centre, Nairobi, KENYA
+[lucy (dot) waruingi (at) acc (dot) or (dot) ke](mailto:lucy.waruingi@acc.or.ke)
+
+### Asia
+
+Ji Liqiang
+Institute of Zoology, Chinese Academy of Sciences, CHINA
+[ji (at) ioz (dot) ac (dot) cn](http://ji/%28at%29ioz.ac.cn/)
+
+### Europe
+
+Wouter Addink
+Naturalis Leiden, NETHERLANDS
+[wouter (dot) addink (at) naturalis (dot) nl](mailto:wouter.addink@anturalis.nl)
+
+### Latin America
+
+Bruno de Carvalho Albertini
+University of Sao Paulo, BRASIL
+[balbertini (at) gmail (dot) com](mailto:balbertini@gmail.com)
+
+### North America
+Cynthia Parr
+National Agricultural Library, USDA, Beltsville, MD, USA
+[csparr (at) tdwg (dot) org](mailto:csparr@tdwg.org)
+
+### Oceania
+
+Aaron Wilton
+Landcare Research, NEW ZEALAND
+[WiltonA (at) landcareresearch (dot) co (dot) nz](mailto:wiltona@landcareresearch.co.nz/)
+
+## Co-opted Members (Non-Voting)
+
+### Conference Program Committee Co-Chair
+
+Gail Kampmeier
+Urbana-Champaign, IL, USA
+[gkamp (at) illinois (dot) edu](mailto:gkamp@illinois.edu)
+
+### TDWG Coordinator
+
+Stan Blum
+San Fancisco, USA
+[stanblum (at) gmail (dot) com](mailto:stanblum@gmail.com)

--- a/content/pages/about/committees/fundraising.md
+++ b/content/pages/about/committees/fundraising.md
@@ -1,1 +1,47 @@
 title: Fundraising and partnerships subcommittee
+
+_Copied from <https://github.com/tdwg/charters/blob/master/charters/partnerships.md>_
+
+## Mission
+
+TDWG FPFS will work together with TDWG executive committee as well as TDWG task and interest groups to submit and implement competitive funding bids and improve the position of TDWG in the international landscape through strategic partnerships at international, regional or national level.
+
+### Responsibilities
+
+On behalf of the TDWG Executive Committee the FPFS will undertake work related to the following objectives:
+
+#### Fundraising
+
+##### Scientific fundraising 
+
+1. Horizon scanning at regional and international level, for the identification and assessment of funding opportunities, associated with:
+    1. Research and innovation supporting funds
+    1. Coordination and support funds for international organisations;
+1. Preparation of bids and consortium development activities;
+1. Act as the TDWG liaison group in multi-partner projects, providing facilitating access to TDWG resources and acting as Task or Work Package leader, where necessary;
+1. Lead in writing tasks for the development of funding proposals.
+
+##### Other fundraising
+
+1. Work together with relevant Functional Subcommittees to prepare material for the engagement of organisations to support corporate fundraising activities;
+1. Set out a short and mid-term strategy and action plan for corporate and wealthy individuals engagement;
+1. Implement tasks according to the action plan.
+
+#### Partnerships
+
+1. Identify and engage with international organisations to strengthen the position of TDWG and raise its international profile;
+1. Maintain a registry of stakeholders based on alignment of strategic interests with TDWG.
+1. After consulting with the TDWG Executive Committee, submit for signature to TDWG chair and monitor the implementation of memoranda of understanding or other non-legally binding collaboration documents with identified stakeholders;
+1. Assign representatives for the participation in business meetings of collaborating organisations.
+
+## Organization 
+
+### Charter 
+
+According to TDWG Constitution, the charter may be revised by the the TDWG Executive Committee according to the strategic priorities of the organisation. Changes to the charter will be put up for open membership consultation for 30 days prior to approval.
+
+### Membership and Meetings
+
+The FPFS will be convened by the directly elected from the TDWG membership chair of the FS. The chair shall be elected by the TDWG membership. The chair is responsible for appointing sub-committee members and a deputy chair. The FS will operate with 5-7 members. 
+
+The FS will convene on a regular basis, at least every three months through physical or online meetings. The chair or deputy chair will also be able to call for an ad-hoc meeting or workshop to address urgent matters.

--- a/content/pages/about/committees/infrastructure.md
+++ b/content/pages/about/committees/infrastructure.md
@@ -1,1 +1,44 @@
 title: Infrastructure subcommittee
+
+_Copied from <https://github.com/tdwg/charters/blob/master/charters/infrastructure.md>_
+
+## Mission
+
+The purpose of the Infrastructure Functional Subcommittee (FS) is to maintain the software tools required to support the operation of TDWG.
+
+TDWG is an open community and participants require the means to discuss, coordinate, document, vote on, and version the development of biodiversity data standards. The TDWG organization needs the means to present and communicate its work, manage financial matters and run the annual conference. The FS exists to advise the executive committee and membership on software solutions to achieve these goals, to assist in developing and documenting information processes, and to oversee implementation and maintenance of the selected tools.
+
+## Responsibilities
+
+### Scope
+
+To oversee the operation and coordinate the development of the software tools in use by TDWG including:
+
+1. TDWG website development, hosting, DNS, operating system upgrades, intrusion detection, etc. 
+1. Versioning, collaborative development, archival and distribution mechanism for standards (i.e. the use of GitHub)
+1. Tools to support collaborative documentation authoring
+1. Communication and discussion tools such as mailing lists, wikis, Slack.com, etc.
+
+The FS will coordinate and lead the technical helpdesk which supports the TDWG committees, interest- and working groups in the full lifecycle of their work. This includes advice on establishing communication channels, guidelines for documenting and discussing results, preparation for community voting, archival and publication of results, cleanup.
+
+### Oversight of implementation
+
+The FS will evaluate potential software tools of interest to TDWG and provide recommendations to the community and for decision by the executive committee. Once approved, the infrastructure FS will be tasked with overseeing the implementation of these software tools, including the management of related sub-contracted work. 
+
+## Organization
+
+### Charter 
+
+According to TDWG Constitution, the charter may be revised by the the TDWG Executive Committee according to the strategic priorities of the organisation. Changes to the charter will be put up for open membership consultation for 30 days prior to approval.
+
+### Membership, structure, and quorum
+
+The chair shall be elected by the TDWG membership. The chair is responsible for appointing sub-committee members and a deputy chair. The FS shall contain between 3 and 7 members. The FS members should have experience in system administration, running content management systems, developing websites, collaborative version control systems for documents and software or in providing technical helpdesk tasks.
+
+### Meetings
+
+The FS shall convene by teleconference (e.g. over Skype) at least two times per year. A quorum of any meeting of the infrastructure FS shall consist of a majority of its current members. 
+
+### Agenda, minutes, and reports
+
+The FS chair, in collaboration with the deputy, shall be responsible for establishing the agendas for meetings. An open issue tracking system will be used (e.g. GitHub issues) to ensure transparency of work and for assignment of tasks.

--- a/content/pages/about/committees/outreach.md
+++ b/content/pages/about/committees/outreach.md
@@ -1,1 +1,46 @@
 title: Outreach and communications subcommittee
+
+_Copied from <https://github.com/tdwg/charters/blob/master/charters/outreach.md>_
+
+## Motivation
+
+This year (2016) TDWG aims to recast the organization of TDWG and its activities with a number of functional sub-committees focused on different aspects of the of TDWG activities and encourage more involvement of domain experts in the workings of TDWG. Towards this end a functional sub-committee will be dedicated to outreach and communication with an elected chair of the sub-committee. The chair will be a member of the executive committee of TDWG and report on the activities of outreach and communication. 
+
+## The Draft Outreach and Communications (OAC) charter
+
+### Mission
+
+Promote TDWG activities and recruit members around the world. Craft and share meaningful stories about TDWG standards and their application. Develop materials that can be used by all TDWG members 
+
+### Responsibilities
+
+OAC responsibilities will focus on the effective outreach and communication of the TDWG vision and mission.
+
+The charter of activities of the OAC sub-committee on behalf of TDWG would be the following:
+
+* Commission and solicit outreach and communication material on TDWG and its activities.
+* Maintain a page on the TDWG site for all outreach and communication material under open access and CC0 licenses. 
+* Provide information and links to standards in use and standards in development for biodiversity information
+* Encourage regional representatives and members of TDWG to run programs to expose TDWG activities and report them to the executive committee. 
+
+## Organization
+
+### Charter
+
+The charter may be revised as and when necessary by the OAC and changes submitted for the approval of the Executive Committee of TDWG.
+
+### Membership
+
+The chair shall be elected by the TDWG membership. 
+
+The Executive Committee Chair in consultation with the OAC Chair is responsible for appointing sub-committee members and a vice-chair.
+
+OAC should be between 5 and 7 members, ideally with representation from different regions and with different expertise, with specific orientation for outreach and communication of the activities of TDWG. 
+ 
+### Meetings, documentation and reporting
+
+The OAC reports to the TDWG executive.   
+
+The OAC will formally convene at least twice each year.  A quorum will be a majority of members of the OAC committee.  Meetings will be conducted using Internet technologies and Members may participate on-line.  Agenda for formal meetings will be prepared by the Chair and distributed to members at least 14 days in advance. 
+
+Agenda and minutes for all meetings and all requests, decisions and responses will be posted to an appropriate repository.

--- a/content/pages/about/committees/tag.md
+++ b/content/pages/about/committees/tag.md
@@ -1,1 +1,47 @@
 title: Technical architecture group
+
+_Copied from <https://github.com/tdwg/charters/blob/master/charters/tag.md>_
+
+## Mission
+
+The Technical Architecture Group (TAG) will guide ongoing development of the TDWG technical architecture and advise the Executive and membership on matters relating to the principles, strategies and practice for maintaining the common technical framework essential to TDWG's mission to develop, adopt and promote standards and practice for the recording and exchange of biodiversity data.
+
+## Responsibilities
+
+TAG responsibilities will be limited to technical aspects of the TDWG architecture.
+
+On behalf of the executive, maintain oversight and report on:
+
+* Issues of standards acceptance and compliance
+* The status of existing standards - their completeness, interoperability and limits
+* The technical evaluation of task group proposals and their reports
+* Coordination of technical activities across Interest Groups
+* Completeness of standards documentation and management
+* Interaction with external standards activity
+
+Working with the membership to advance a common standards framework:
+
+* Coordinate update and maintenance of the TDWG Technical "Road Map" and best practice documentation
+* Maintain the TAG GitHub presence
+
+## Organization
+
+### Charter
+
+According to TDWG Constitution, the charter may be revised by the the TDWG Executive Committee according to the strategic priorities of the organisation. Changes to the charter will be put up for open membership consultation for 30 days prior to approval.
+
+### Membership
+
+The chair shall be elected by the TDWG membership. The chair is responsible for appointing sub-committee members and a deputy chair. The TAG shall contain between 5 and 9 members, ideally with representation from core, standards maintenance interest groups and major implementors. The TAG may call on external, expert assistance as required.
+
+### Meetings, documentation, and reporting
+
+The TAG reports to the TDWG executive.
+
+The TAG will maintain both a private and public GitHub repository for all TAG documentation, and issue and request management.
+
+The TAG will formally convene at least twice each year. A quorum will be a majority of voting members. Meetings will be conducted using internet technologies and members may participate online. Agenda for formal meetings will be prepared by the chair and distributed to members at least 14 days in advance.
+
+Because the TAG may receive time sensitive Executive Requests for advice or response at any time, a combination of issue tracker, e-mail and internet technologies will be used to conduct TAG business online, and to convene extra-ordinary meetings at short notice, as required.
+
+Agenda and minutes for all meetings and all requests, decisions and responses will be posted to the TAG repository.

--- a/content/pages/about/committees/tardis.md
+++ b/content/pages/about/committees/tardis.md
@@ -1,1 +1,34 @@
 title: Time and place subcommittee
+
+_Copied from <https://github.com/tdwg/charters/blob/master/charters/timeandplace.md>_
+
+## Mission
+
+The Time and Place Functional Subcommittee (FS) mission is to establish a six year rolling plan for the hosting of TDWG meetings, which seeks to expand the influence of TDWG whilst retaining and increasing its core membership base. It is aiming at expanding the TDWG community, maintaining existing community, maintaining functionality of interest and task groups, and taking advantage of funding for hosting opportunities.
+
+## Responsibilities
+
+1. Develop a broad planning document for location and timing of conferences for the next 6 years
+1. Develop process and documents for:
+    1. seeking expressions of interest
+    1. lodging expressions of interest for hosting conferences
+    1. selection of conference locations and times
+    1. detailed submission by preferred host for final acceptance
+
+## Organization
+
+### Charter 
+
+According to TDWG Constitution, the charter may be revised by the the TDWG Executive Committee according to the strategic priorities of the organisation. Changes to the charter will be put up for open membership consultation for 30 days prior to approval.
+
+### Membership, structure, and quorum
+
+The chair shall be elected by the TDWG membership. The chair is responsible for appointing sub-committee members and a deputy chair. The FS shall contain between 3 and 7 members. The FS may call on external, expert assistance as required.
+
+### Meetings
+
+The FS shall convene by teleconference (e.g. over Skype) at least two times per year. A quorum of any meeting of the FS shall consist of a majority of its current members. 
+
+### Agenda, minutes, and reports
+
+The FS chair, in collaboration with the deputy, shall be responsible for establishing the agendas for meetings. An open issue tracking system will be used (e.g. GitHub issues) to ensure transparency of work and for assignment of tasks.

--- a/content/pages/about/constitution.md
+++ b/content/pages/about/constitution.md
@@ -1,2 +1,159 @@
 title: Constitution
 page_order: 3
+
+_Copied from <https://github.com/tdwg/constitution/blob/master/constitution.md>_
+
+## Article 1. Name and Purpose
+
+The International Working Group on Taxonomic Databases (herein called "TDWG") is a not-for-profit, scientific and educational association formed to establish international collaboration among the creators, managers and users of biodiversity information so as to promote the wider and more effective dissemination of information about the world's heritage of biological organisms for the benefit of the world at large.
+
+To achieve its goals, TDWG
+
+1. develops, adopts and promotes standards and guidelines for the recording and exchange of data about organisms;
+2. promotes their use through the most appropriate and effective means;
+3. acts as a forum for discussion through holding meetings and through publication and
+4. undertakes any other activities that are judged useful to the organisation.
+
+## Article 2. Affiliation and Incorporation 
+
+TDWG may affiliate to or cooperate with other associations or organisations with similar or complementary aims.
+
+TDWG is incorporated and operates in the State of California of the United States of America.  TDWG may obtain legal status under the laws of other countries in which it decides to operate.
+
+## Article 3. Membership
+
+Membership is open to individuals and other legal entities, including institutions, organisations, companies, and government agencies.
+
+Membership consists of two classes:
+
+1. individual members and
+2. institutional members (other legal entities).
+
+Membership is acquired by payment of the current year's membership fee. The Executive Committee may waive the membership fee of a member.
+
+Members are entitled to vote, hold office, and receive TDWG publications.
+
+Membership ends upon written resignation addressed to the Chair, Secretary, or Treasurer, or by failure to pay membership dues, or in cases of professional misconduct.
+
+## Article 4. Meetings
+
+TDWG shall meet each calendar year to discuss standards; advance and promote biodiversity informatics; receive reports on TDWG activities, including a financial report; discuss governance and operation; and conduct other relevant business.
+
+## Article 5. Executive Committee
+
+### 5.1 Composition
+
+TDWG is governed by an Executive Committee consisting of ten officers elected from and by the membership (the Chair, Deputy Chair, Secretary, Treasurer, and six Representatives), and the chairs of the TDWG Functional Subcommittees, who serve *ex officio*, as defined in Articles 6 and 7.  At no time shall a majority of the Executive Committee, as a whole or in quorum, be composed of individuals who have familial or business relationships. 
+
+### 5.2 Roles and responsibilities  
+
+The Executive Committee:  
+
+1. provides leadership to TDWG;
+2. promotes TDWG to the broader community;
+3. organizes the day to day affairs of TDWG;
+4. may appoint an individual or group of individuals to perform specific work or an ongoing function for TDWG;
+5. defines the number, scope and role of Functional Subcommittees;
+6. proposes the amount of dues and a multiplier for votes cast by institutional members on election of officers (subject to ratification by the membership);
+7. administers and retains fiduciary responsibility for the assets, and arranges audits;
+8. prepares and presents the annual budget to the membership;
+9. has power to apply for legal status for TDWG;
+10. has other powers as stated elsewhere in this Constitution and any by-laws;
+11. provides timely notification of progress towards goals; and
+12. otherwise acts to fulfil the goals of TDWG.
+
+### 5.3 Executive Committee meetings and quorum  
+
+The Executive Committee shall meet and report to the membership at least once each calendar year.  
+
+A majority of Executive Committee members constitutes a quorum and must participate to conduct official business. Because TDWG is a global organization, participation is not required to be in real-time.  Pariticipation may include communication by any means accessible to all members, such as meeting in person, by teleconference, online chat, email, and document sharing. Voting may be by voice, gesture, paper, or electronic expression as directed by the Chair.
+
+### 5.4 Conflicts of interest
+
+TDWG shall develop, adopt, and maintain a Conflict of Interest Policy.  The Executive Committee as a whole, and each member individually, must abide by that policy.  
+
+## Article 6. Executive Committee Members
+
+### 6.1 Elections and terms
+
+General elections shall be organised every year under the responsibility of the Executive Committee. Election results become effective from the start of the calendar year following the elections. Officers (Secretary, Treasurer and Representatives) shall be elected directly from the membership for terms of two years. The Executive Committee Chair is elected directly from the membership, serves as Deputy Chair for two years, and then serves as Chair in the following two years, as described in Article 6.2. Terms in the Executive Committee shall be staggered, such that approximately half of the positions are elected each year.
+
+### 6.2 Executive Committee Chair and Deputy Chair
+
+The Executive Committee Chair is elected directly from the membership and commits to a total of four years of service.  A newly elected Chair serves first as Deputy Chair for two years, and then succeeds to become Chair for the following two years. Upon completion of both terms, the Chair can opt to remain as a member of the Executive Committee for an additional two years as a TDWG representative. 
+
+If an Executive Committee Chair resigns or otherwise becomes unable to fulfill the role, the Deputy Chair shall become Chair, and a new Deputy Chair shall be elected in the next general election.  In the event that both a Chair and Deputy Chair become unable to serve, the Executive Committee shall appoint one of the current TDWG officers to serve as Acting Chair, and both Chair and Deputy Chair shall be elected in the next general election.
+
+#### 6.2.1 Executive Committee Chair responsibilities
+
+Presides at meetings of TDWG and at meetings of the Executive Committee; convenes Executive Committee meetings; is entitled to sign jointly with one other officer on behalf of TDWG; enacts such functions as are assigned by the Executive Committee; represents TDWG at external meetings; delegates on an ad-hoc basis the above responsibilities to other Executive Committee members.
+
+#### 6.2.2 Executive Committee Deputy Chair responsibilities 
+
+The Deputy Chair enjoys full voting rights in the Executive Committee, stands in for the Chair as necessary, and assists with tasks of the Secretary and Treasurer.
+
+### 6.3 Secretary
+
+The Secretary operates the secretariat; keeps, distributes, and publishes minutes of meetings; sends notices of the annual meeting to the membership and notices of meetings of the Executive Committee to its members; distributes proposals and organizes votes; conducts the general elections; authenticates, tallies, and publishes voting results.
+
+Communications to and from the Executive Committee involving formal TDWG business should be via the Secretary who must arrange a proxy from among Executive Committee members for any significant period of unavailability. 
+
+### 6.4 Treasurer
+
+The Treasurer is entitled to sign jointly with one other officer on behalf of TDWG; maintains the membership list; reports finances annually to the membership; collects membership dues and other TDWG income; maintains the financial documents and accounts of TDWG; administers the assets of TDWG in conformance with instructions from the Executive Committee.
+
+### 6.5 Chairs of functional subcommittees
+
+Chairs of Functional Subcommittees (see Article 7) participate, *ex officio*, as full members of the Executive Committee. They liaise between their subcommittees and the TDWG Executive Committee, summarise activities, and discuss strategic priorities and future plans in regards to subcommittee responsibilities.  
+
+### 6.6 Elected Representatives
+
+Have the responsibility to represent the interests of TDWG members on the Executive Committee; and to represent TDWG in appropriate meetings and other activities. The number of available seats for Representatives in the Executive Committee is six (as per Article 6.7).
+
+### 6.7 Geographical distribution of Representatives
+
+The Executive Committee shall encourage participation from the membership across geographical boundaries, gender, age, ethnicity, and professional expertise. To encourage balanced representation one representative will be elected from each of the following regions: Africa, Asia, Europe, Latin America, North America, and Oceania. 
+
+## Article 7. Functional Subcommittees
+
+### 7.1 Definition, role and scope 
+
+Functional Subcommittees (FS) are committees operating under specific mandates, set by the Executive Committee in response to identified needs of TDWG. The overarching role of a FS is to assist the Executive Committee in its standing tasks. FS operate under charters prepared and approved by the Executive Committee, following consultation with the membership.   
+
+### 7.2. Establishment, duration and dissolution
+
+The scope and mode of operations for each Functional Subcommittee are defined by their published charters. Following approval by the Executive as in Paragraph 7.1, a FS is established and fully effective at the moment of election of its chairperson. FS charters shall be presented to the membership for open consultation for at least 21 days prior to approval by the Executive. Following the Executive Committee’s decision to dissolve a FS, it remains effective until the end of the FS chairperson’s term of duty, as defined in Paragraph 7.3.
+
+### 7.3 Functional subcommittee membership and leadership
+
+The chair of each FS is elected during the TDWG general elections. FS chairs are elected for two full calendar years. FS chairs are responsible for appointing a deputy-chair with attending and no voting rights at Executive Committee meetings. FS chairs invite members and manage membership in their respective committees. Each committee shall operate with more than three and fewer than 15 members. In case of resignation of a FS chair, the deputy chair will be invited to take the place of the chair until the next general elections and a new deputy is appointed.
+
+## Article 8. Assets
+
+The revenue of TDWG shall consist of membership dues, sales of publications, lease of rights, grants, gifts and bequests, income from investments, and any other kinds of income compatible with the aims of TDWG.
+
+The assets of TDWG shall be used exclusively for the statutory aims and purposes, and in no case to the immediate profit of its members.
+
+The financial year shall be the calendar year.
+
+## Article 9. Amendments
+
+Alterations to the Constitution may be proposed by the Executive Committee, or may be submitted in writing to the Executive Committee by either at least five individual members from at least two countries, or at least three institutional members from at least two countries. The proposed alteration must be published and the membership notified at least ninety days before close of voting. To be accepted, the proposed alteration must receive simple majorities of affirmative votes from both individual members and institutional members.
+
+The Executive Committee may propose that by-laws be established, altered, or repealed. The by-laws proposal must be published and the membership notified at least thirty days before the close of voting. To be adopted, the proposal must receive simple majorities of affirmative votes from both individual and institutional members.
+
+## Article 10. Dissolution
+
+Dissolution of TDWG can only be enacted by a two-thirds majority of both individual and institutional members by vote. A proposal of dissolution must be dispatched by the Executive Committee to the membership at least ninety days before close of voting.
+
+Upon the dissolution of TDWG, any net remaining assets shall be transferred to the International Association for Plant Taxonomy, provided that at the time of TWDG’s dissolution, that organization is a qualified 501(c)(3) organization. If this organization no longer exists or is not qualified, TWDG’s assets will be distributed to another qualified 501(c)(3) organization or internationally qualified charitable organization.  
+
+## Article 11. Voting
+
+TDWG shall strive to make decisions based on broad consensus rather than simple majority. The Executive Committee may assess consensus through mechanisms other than voting, such as solicited reviews and public requests for comment, except where voting is mandated elsewhere in this Constitution. If a broad consensus cannot be reached, the Executive Committee may arrange for an issue to be decided by a vote of the membership.
+
+In general elections of officers, each current member will be entitled to one vote, but may abstain.  On counting, each institutional vote will be weighted using the current fees-based multiplier and the candidate receiving a plurality of the totalled votes shall be appointed to the office (see Article 5, item 6). 
+
+In questions of governance and other issues requiring a simple decision to accept or reject a proposal, the votes of Individual and Institutional members will be tallied separately, without weighting, and a proposal will pass if it receives a simple majority of the votes cast in each membership category.
+
+The Executive Committee shall specify the schedule and mechanism(s) for making nominations for elected positions and casting votes. Any voting procedure should afford each member an opportunity to vote in an expedient manner and should not unduly delay decision making. The Secretary shall authenticate, tally, and publish voting results within a reasonable timeframe.

--- a/content/pages/about/contact.md
+++ b/content/pages/about/contact.md
@@ -1,2 +1,25 @@
 title: Contact
 page_order: 5
+
+For official business with the TDWG Executive Committee, such as reports and applications, please contact the TDWG Secretary. For questions and comments concerning TDWG and our website, please contact Stan Blum at the TDWG Secretariat (see below, email preferred).
+
+Quentin Groom
+[TDWG Secretary](javascript:linkTo_UnCryptMailto('ocknvq,ugetgvctaBvfyi0qti');)
+Brussels, Belgium
+
+Stan Blum
+[TDWG Coordinator](javascript:linkTo_UnCryptMailto('ocknvq,ugetgvctkcvBvfyi0qti');)
+San Francisco, CA USA
+
+## Secretariat (legal mailing address)
+
+```
+TDWG
+1342 34th Ave.
+San Francisco, CA 94122
+USA
+```
+
+Telephone:  +1 415-779-2858
+Pacific Daylight Time (UTC-7)
+Pacific Standard Time (UTC-8)

--- a/content/pages/community.md
+++ b/content/pages/community.md
@@ -1,2 +1,25 @@
 title: Community
 page_order: 2
+
+_Copied from <http://www.tdwg.org/activities/>_
+
+Activities listed here are the TDWG Interest and Task Groups approved by the Executive Committee to work on standards in a particular area of biodiversity science.
+
+Links on the group abbreviation and full name should take you to the group's landing page or charter. Links under the Resources column indicate the group's primary collaboration tools.
+
+[TDWG mailing lists](http://www.tdwg.org/activities/mailing-lists/): Several years ago, TDWG members observed that a separate mailing list for each interest or task group was overly partitioned. Topics discussed in one group were often relevant to multiple groups and it was difficult to ensure that everyone interested in a topic was kept informed. To fix the problem, TDWG merged most mailing lists into just three:
+
+* TDWG -- for general announcements (very low volume)
+* TDWG-Content -- for discussing how biodiversity information concepts should be defined and represented; and
+* TDWG-TAG -- for discussing technical architecture.
+
+In addition, TDWG is moving many of its groups to [GitHub](https://github.com/tdwg) because the collaboration tools provided there are an excellent platform for developing information standards.
+
+For further information, please [contact us](http://www.tdwg.org/about-tdwg/contact-us/).
+
+## Information for Conveners
+
+Helpful information for Interest and Task Group Conveners
+
+* [Responsibilities](http://www.tdwg.org/activities/convener-responsibilities/) of Conveners, including guides and templates
+* The [TDWG Community Support Fund](http://www.tdwg.org/activities/comm-support-fund/)

--- a/content/pages/community.md
+++ b/content/pages/community.md
@@ -1,2 +1,2 @@
 title: Community
-page_order: 3
+page_order: 2

--- a/content/pages/community/annotations.md
+++ b/content/pages/community/annotations.md
@@ -1,1 +1,37 @@
 title: Annotation interest group
+
+_Copied from <http://www.tdwg.org/activities/annotations-test/>_
+
+# TDWG: Annotations
+
+TDWG Interest Group (Open) Convener Paul J. Morris
+Biodiversity Informatics Manager Harvard University Herbaria/Museum of Comparative Zoology
+22 Divinity Ave Cambridge, MA 02138 USA
+
+## Core Members
+
+* James A. Macklin, james.macklin(at)agr.gc.ca
+* Robert A. Morris, morris.bob(at)gmail.com
+* Greg Riccardi, griccardi(at)fsu.edu
+* Walter G. Berendsohn, w.berendsohn(at)bgbm.org
+* Donald Hobern, Donald.Hobern(at)csiro.au
+* Tim Robertson, trobertson(at)gbif.org
+
+## Motivation
+
+This group serves as a forum for the discussion of mechanisms and concepts for the annotation of all kinds of biodiversity data.
+
+The Annotations Group will discuss, evaluate, propose, and standardizemechanisms for the collection, distribution, and storage of annotations of biodiversity data. The scope of annotations is potentially broad, encompassing, among others, structured and unstructured textual data, multimedia, and data set metadata, with obvious interactions with other TDWG groups and with existing and proposed standards in the domain.
+
+The group provides a forum for the advancement of existing and new mechanisms for the annotation of biodiversity data towards standards related to the structure, capture, transport, and management of annotations. The group will develop:
+
+1. Summary information about annotation standards and mechanisms for both data in general and scientific data in particular;
+2. Descriptions of annotation concepts and annotation management technologies in use and in development in the biodiversity informatics community;
+3. Descriptions of implementations of annotation capture, transport, and management mechanisms in use and in development in the biodiversity informatics community; and
+4. Applicability statements of annotation standards and concepts from other communities.
+
+## Becoming involved
+
+The Annotations Group is open to all interested parties. You can add yourself to the mailing list. Full membership is available to individuals who intend to be materially active in the group by request to the Convener. We are currently seeking reference implementations of annotation mechanisms and case studies for the annotation of data in general. Biodiversity informatics datasets are seldom, if ever, finished. New assertions are continually being made about biodiversity data, which may change their interpretation or require update of resources based on them. With subsequent study, researchers may apply new determinations to specimens. The scope of taxonomic concepts and taxon names change over time, as do geopolitical boundaries and names. Biodiversity data are continually enriched, for example, by extractions to add molecular profiles or dissections to improve morphological knowledge. Each piece of data may be distributed and linked in ways in which an assertion concerning a part of one data set is highly relevant to data being used elsewhere. Images of a specimen may be held in one or more repositories that are different from where its physical specimen is housed and any of these repositories may be the sites for new assertions about the data that are relevant to records in more places than the sites where the assertions are collected. Assertions about scientific data can be viewed as annotations of those data, with associated motivations, actions, and decisions that document the history of proposed, accepted, and rejected changes to those data. The domain content of an annotation is likely to be well described by existing, proposed, or future standards in the domain (e.g. Darwin Core, SDD, TCS, MRTG), but the concern of the annotation is at a different level. For example, an annotation might carry a Darwin Core assertion about a new determination of a specimen, but also assert that the determination is based upon a set of characters observed in particular regions of interest in a set of images of that specimen as seen by the annotator in an image repository. These linkages amongst the who, where, why, what, and when of assertions about data are the particular concerns of annotations. Annotations span many scales from change tracking within an individual data set to transport and linking of assertions across heterogeneous distributed data.
+
+The Annotations Interest Group will provide a forum for discussion about all aspects of annotations in biodiversity informatics, develop cross-linkages with other interest groups and standards, and generate Task Groups to develop specific standards and best practices related to the annotation of biodiversity data.

--- a/content/pages/community/attribution.md
+++ b/content/pages/community/attribution.md
@@ -1,1 +1,15 @@
 title: Attribution interest group
+
+_Copied from <https://github.com/tdwg/attribution/blob/master/README.md>_
+
+This interest group is a collaboration between TDWG and the Research Data Alliance to enhance existing and create new standards for giving attribution for the maintenance, curation, and digitization of physical and digital objects with a special emphasis on biodiversity collections. This group will produce use cases from a variety of disciplines that will be used to create the final deliverable – an attribution metadata schema.
+
+## Rationale
+
+Despite the importance of research collections, many are not maintained or curated as thoroughly as they should. Part of the reason for this is the lack of professional reward for curatorial actions. Most of the researchers who are qualified to curate a collection are too busy performing activities that will reap professional reward, such as publication and grant-writing. Proper methods of attribution (at the individual and institutional level) are very important for incentivizing digitization, mobilization. And sharing of data deriving from collections (physical and digital). One strategy for incentivizing physical and digital collection curation is to create infrastructure for attributing curatorial actions. Several programs exist for aggregating metrics for research products other than publication, such as ImpactStory, OpenVIVO, Collector, and Altmetrics. Thus, there is already infrastructure in place for aggregating these data, if the infrastructure for creation of these data is available.
+
+## How to contribute
+
+* Watch this github project.
+* Submit or comment on an issue on this github project.
+* Join the RDA/TDWG Working Group at the RDA website <https://www.rd-alliance.org/groups/metadata-standards-attribution-physical-and-digital-collections-stewardship.html>

--- a/content/pages/community/bdq.md
+++ b/content/pages/community/bdq.md
@@ -1,1 +1,60 @@
 title: Biodiversity data quality interest group
+
+_Copied from <http://www.tdwg.org/activities/biodiversity-data-quality/interest-group-charter/>_
+
+## Conveners
+
+Antonio Mauro Saraiva
+Full Professor, Universidade de Sao Paulo, Escola Politecnica
+Computing and Digital Systems Engineering Department
+Coordinator - Research Center on Biodiversity and Computing - BioComp. USP
+Av. Prof. Luciano Gualberto, travessa 3, nº 158, sala C2-56
+São Paulo, Brazil
+Email: saraiva(at)usp.br
+
+Arthur D. Chapman
+Australian Biodiversity Information Services
+PO Box 35, Ballan,  Victoria, Australia 3342
+Email: biodiv_2(at)achapman.org
+
+## Core members
+
+* Aaike De Wever - Royal Belgian Institute of Natural Sciences, BioFresh, Belgium
+* Alex Thompson - iDigBio Project
+* Allan Koch Veiga - BioComp, University of São Paulo (USP)
+* Arturo H. Ariño - GBIF-Spain, Universidad de Navarra (UNAV) 
+* Christian Gendreau - Canadensys
+* Dag Endresen - GBIF-Norway, Natural History Museum at the University of Oslo, Norway
+* Daniel Lins da Silva - BioComp, University of São Paulo (USP)
+* David Bloom - VertNet
+* David Fichtmueller - Botanic Garden and Botanical Museum Berlin-Dahlem (BGBM), Germany
+* Debbie Paul - iDigBio
+* Dimitri Brosens - Belgian Biodiversity Platform
+* Dmitry Schigel - GBIF
+* Éamonn Ó Tuama - GBIF
+* Etienne Américo Cartolano Júnior - BioComp, University of São Paulo (USP)
+* Hanna Koivula - Finnish Museum of Natural History, University of Helsinki
+* James Macklin - AAFC National Vascular Plant Collection (DAO)
+* Javier Otegui - University of Colorado, USA
+* John Wieczorek - Museum of Vertebrate Zoology, University of California Berkeley
+* Jorge Rady de Almeida Júnior - University of São Paulo (USP)
+* Laura Russell - VertNet
+* Luiz Manoel Rocha Gadelha Junior - National Laboratory for Scientific Computing, Brazil
+* Lutz Suhrbier - Botanic Garden and Botanical Museum Berlin-Dahlem (BGBM), Germany
+* Márcia Beatriz Pereira Domingues - BioComp, University of São Paulo (USP)
+* Matthew Collins - ECE University of Florida, iDigBio Project
+* Nicolas Noé - Belgian Biodiversity Platform
+* Rui Figueira - GBIF Portugal, Instituto de Investigação Científica Tropical
+* Vijay Barve - FRLHT, India
+
+## Summary
+
+The goal of this Interest Group is to discuss, determine, formalize and standardize concepts, problems, policies, metadata, methodologies and mechanisms related to Biodiversity Data Quality, collaboratively and incrementally, and to promote associated best practices throughout the Biodiversity Informatics community. Data quality is a major concern in Biodiversity Informatics. The distributed nature of data acquisition and digitization, the specific difficulties imposed by some of the data sub-domains, such as taxonomic data and geographic data, among other aspects, make it important to discuss data quality in biodiversity so that data made available in portals and other systems can be used for various purposes such as education, science, and decision making. Although several initiatives in the Biodiversity Informatics community have been striving to develop tools and best practices about Data Quality, we lack a common background and consensus related to concepts, metadata, policies, and methodologies that would increase the synergy in achieving solutions for improving the fitness-for-use of biodiversity data. In this Interest Group we want to develop this common background and help standardize the way to deal with Data Quality in the Biodiversity Informatics community, avoiding duplication of efforts and sharing knowledge and solutions.
+
+## Becoming Involved
+
+Anyone interested in biodiversity data quality is encouraged to become involved with the Interest Group or any of its Task Groups. Membership of the group is open. If you work with biodiversity data at any level, whether digitization, publication, integration or analysis, and you would like to be able to measure and manage Data Quality to allow others to assess the fitness-for-use of your data, the Biodiversity Data Quality Interest Group may benefit from your involvement.
+
+Please contact the convenor or any core member about how to become involved. 
+
+The TDWG process requires that any new Task Group be launched through an Interest Group. The Biodiversity Data Quality Interest Group can facilitate establishment of new Task Groups that relate to this topic. Please contact the convenor to discuss potential projects or join existing Task Groups.

--- a/content/pages/community/curriculum.md
+++ b/content/pages/community/curriculum.md
@@ -1,1 +1,90 @@
 title: Biodiversity informatics curriculum interest group
+
+_Copied from <http://www.tdwg.org/activities/bdi-curriculum-ig/charter/>_
+
+## Convener
+
+Hanna Koivula   
+Finnish Environment Institute (SYKE)
+Yliopistokatu 7, FI-80100 Joensuu, FINLAND
+Email: hanna.koivula [at] iki.fi
+
+## Core members
+
+We will collect core members via email (hanna.koivula(at)iki.fi) and on the GBIF community site. All GBIF community site pages are visible for anyone, but for comments user must register.  <http://community.gbif.org/pg/groups/30748/interest-group-on-biodiversity-informatics-training/>
+
+### Initial list of core members
+
+Dimitris Koureas 
+The Natural History Museum London Dept of Life Sciences 
+Biodiversity Informatics Group, SW7 5BD, UK 
+Email: d.koureas(at)nhm.ac.uk
+
+Alberto González-Talaván 
+GBIF Secretariat 
+Universitetsparken 15, DK-2100 Copenhagen, Denmark 
+Email: atalavan(at)gbif.org 
+
+Dmitry Schigel 
+GBIF Secretariat Universitetsparken 15, DK-2100 Copenhagen, Denmark 
+Email: dschigel(at)gbif.org
+
+Riitta Tegelberg 
+Digitarium, Finland 
+Email: riitta.tegelberg(at)uef.fi 
+
+Jitendra Gaikwad 
+German Centre for Integrative Biodiversity Research (iDiv), Germany 
+Email: jitendra.gaikwad(at)uni-jena.de
+
+Roman Gerlach
+German Centre for Integrative Biodiversity Research (iDiv), Germany 
+Email: roman.gerlach(at)uni-jena.de 
+
+Falko Glöckler 
+Museum für Naturkunde Berlin, Germany 
+Email: falko.gloeckler(at)mfn-berlin.de
+
+Jana Hoffmann 
+Museum für Naturkunde Berlin, Germany 
+Email: jana.hoffmann(at)mfn-berlin.de 
+
+Patricia Mergen 
+Royal Museum for Central Africa, Belgium 
+Email: Patricia.Mergen(at)africamuseum.be
+
+Larissa Smirnova 
+Royal Museum for Central Africa, Belgium 
+Email: larissa.smirnova(at)africamuseum.be 
+
+Deborah Paul 
+iDigBio, Florida State University, USA 
+Email: dpaul(at)fsu.edu
+
+Bryan Heidorn 
+The University of Arizona, USA 
+Email: heidorn(at)email.arizona.edu 
+
+Jiří Frank 
+National Museum / Národní muzeum, Czech Republic 
+Email: jiri_frank(at)nm.cz
+
+## Motivation
+
+Informatics is becoming a more and more important approach within every field of science. Despite several major data sharing and linking initiatives and facilities for biodiversity data, biodiversity informatics (BDI) still lacks recognition as an independent methodological discipline providing the fundamental set of skills for students and researchers in biodiversity research. To establish this status, offering a biodiversity informatics curriculum as part of all levels of scientific education and related careers becomes essential.
+
+Rather than training to use different tools, the BDI Curriculum Interest Group should lay basis for deeper understanding of the key principles of biodiversity informatics and synthesize the teaching curriculum for different target groups and credit levels in the field. By identifying the target groups and an evolving topics list, the Interest Group can proceed to define a framework i.e. standardized curriculum modules on a conceptual level. Such a framework would support developing educational informatics programmes in a cost-effective way if need be from scratch. This framework would also provide TDWG with a needed platform for knowledge exchange and sharing of content and ideas with the defined modules.
+
+The interest group is formed based on two sessions that took place during TDWG 2014 conference in Jönköping and similar sessions in GBIF Global Nodes Meeting 2015 in Madagascar. 
+
+First concrete tasks for this group would be to identify the target groups, existing expertise and curricula and then collaboratively work to formulate standardized modules that could be used when building a framework curriculum for each target group. Later this Interest group can act as coordinating body for sharing resources, seeking for funding and finding expertise by accumulating and shaping the expertise and survey the needs from the TDWG and the academic communities to develop the curriculum framework further. The IG also aims to initiate and to maintain the discussion of biodiversity informatics curricula from various points of view from academic discipline to training working professionals and career development.
+
+We expect that our activities would contribute to paradigm shift and biodiversity data literacy among young and old biodiversity scientists resulting in neater data. We will contribute to training BDI professionals for the long-term (institutional) and short-term (project) needs. Possible end products include curricula framework, building blocks of the existing teaching programs and complete courses.  
+
+## Becoming Involved
+
+All interested parties are encouraged to become involved with the Interest Group or specific Task Groups it may convene. Membership of the group is open. If you work with biodiversity informatics training at any level, whether it is training working professionals or with the academia, and you would like to be able to find suitable resources and sharing materials and ideas with standardized modules, the Biodiversity Informatics Curriculum Interest Group may benefit from your involvement. Please contact the convener or any core member about how to become involved. The TDWG process requires that any new Task Group be launched through an Interest Group. The Biodiversity Informatics Curriculum Interest Group can facilitate establishment of new Task Groups that relate to this topic. 
+
+## Resources
+
+<http://community.gbif.org/pg/groups/30748/interest-group-on-biodiversity-informatics-training/>

--- a/content/pages/community/gbwg.md
+++ b/content/pages/community/gbwg.md
@@ -1,1 +1,51 @@
 title: Genomic biodiversity interest group
+
+_Copied from <http://www.tdwg.org/activities/genomic-biodiversity/charter/>_
+
+## Convenors
+
+* John Deck, University of California at Berkeley ([email John Deck]())
+* Ramona Walls, iPlant Initiative, University of Arizona
+
+## [Charter Members](http://www.tdwg.org/activities/genomic-biodiversity/charter-members/)
+
+## History and Context
+
+This group is a forum for discussion of standards crossing the biodiversity and genomics fields of study, with core emphasis on mobilizing usable products and technologies for applied research projects.  TDWG has historically focused on the sharing of specimen-based data through a set of standards including Darwin Core (DwC), Access to Biological Collection Data (ABCD), and TDWG Access Protocol for Information Retrieval (TAPIR).  However, the last several years have seen a swell of interest in including DNA-based information with specimen data and coupling sequence data with specimens and their associated environmental and taxonomic context.  For instance, the Consortium for the Barcode of Life (CBOL) has been promoting the acquisition of well curated specimens, photos, and sequence data to define a “barcode” record.  The Moorea Biocode Project has been sequencing and accessioning specimens for an entire island ecosystem.  Meanwhile, the Genomic Standards Consortium (GSC) has a fast-growing Biodiversity Working Group (GBWG) focusing on building appropriate linkages between the genomics and biodiversity communities.   Finally, active efforts are the DNA Extension for Access to Biological Collections Data (ABCDDNA), and work of the Data Standards and Access Task Force for the Global Genome Biodiversity Network (GGBN).
+
+## Motivation
+
+Given that specimen and genomics systems (e.g. Laboratory Information Management Systems (LIMS), sequence repositories) have been poorly integrated in the past and in fact, have largely different cultures, we must develop systems (semantic, application programming interfaces (APIs), and workflows) for integrating these federated systems.  
+
+This interest group will be facilitating communication of the development of tools, vocabularies, and standards of biodiversity genomics to the broader community of TDWG, GSC, and Global Biodiversity Information Facility (GBIF) users. This group will also be sharing and linking with people involved with the development of  ontologies such as Biological Collections Ontology (BCO), Environment Ontology (EnvO) and the Gene Ontology (GO) and finding ways to promote better integration with Darwin Core (DwC), Minimum Information About Any Sequence (MIxS), and other TDWG/GSC standards. 
+
+This interest group overlaps the genomic biodiversity working group (GBWG), formerly called the GSC biodiversity working group.  We operate the TDWG GBWG and the GSC GBWG independently in terms of process even though the groups share their name, members, and collaboration site.  
+
+## Becoming Involved
+
+This group welcomes participation from interested parties with backgrounds in biodiversity, genetics, technical architecture, and taxonomy.  We propose the organization point for this group to be the TDWG website.  Prospective members should refer to the email of the conveners for more information.
+
+The benefit of inclusion in this group is to be informed of, influence, and promote new technologies and standards having to do with genomics and biodiversity and the intersection between the two.  Members will explore new avenues for research for both biologists and informaticians, and garner the opportunities of working directly with a globally diverse set of participants.
+
+## Summary
+
+Biodiversity genomics is a fast-growing field of study that describes biological variation in all its dimensions from the foundational DNA layer to organisms and ecosystems, phylogeny and function.   Much of the data collected in such efforts currently has no consistent vocabulary implementation, standards representation, or implementation for dissemination and integration in the public domain.  This group will facilitate discussion of use cases, form task groups to engage specific deliverables, and communicate relevant advances in biodiversity genomics technologies, vocabularies, and standards to the group members.
+
+Areas that this interest group will be looking at:
+
+* Standards integration efforts (e.g. DwC /MIxS integration)
+* Relevant hackathons for data integration and concept reconciliation
+* Identifying use cases and suitable technologies or gaps for solving them
+
+## Resources
+
+* Genomic Standards Consortium <http://gensc.org/>) and GSC/Genomics Biodiversity Working Group
+* RCN4GSC  (link from <http://wiki.gensc.org/index.php?title=RCN4GSC>)
+* BiSciCol project use cases (<http://biscicol.blogspot.com/>)
+* Genomic Observatories: Taking the genomic pulse of the planet (<http://www.genomicobservatories.org/>)
+* A Genomic Encyclopedia of Bacteria and Archaea (GEBA) (<http://jgi.doe.gov/programs/GEBA/>)
+* The Earth Microbiome Project (<http://www.earthmicrobiome.org/>)
+* Biocode Commons: Tools for supporting genomic observations from collections through analysis (<http://biocodecommons.org/>)
+* Moorea Biocode Project (<http://biocode.berkeley.edu/>)
+* Consortium for the Barcode of Life (<http://www.barcoding.si.edu/>)
+* Biological Collections Ontology (<https://github.com/tucotuco/bco>)

--- a/content/pages/community/imaging.md
+++ b/content/pages/community/imaging.md
@@ -1,1 +1,57 @@
 title: Imaging interest group
+
+_Copied from <http://www.tdwg.org/activities/img/charter/>_
+
+## Convener
+
+Robert A. Morris 
+Department of Computer Science, University of Massachusetts/Boston; 
+100 Morrissdey Blvd; Boston, MA 02125, USA 
+Email: name [at] cs.umb.edu, replace "name" with "ram"
+
+## Purpose
+
+To seed the formation of a full TDWG Subgroup whose purpose would be: To develop standard computer-based mechanisms for managing and transferring descriptive information about media including metadata terminologies, ontologies, descriptions, file exchange formats, and associated resources.
+
+## Background
+
+Many TDWG members have an interest in images. The largest focus at the moment is digitization of specimens (not specimen records), but the increasing importance of observations, which often are documented by images, video, and audio, will lead to an ever greater demand for exchange standards, most notably for content metadata. 
+
+The interest group emerged following an informal brief meeting in Christchurch at the 2004 meeting, and a somewhat longer one at the 2005 meeting in St. Petersburg. The latter gave birth to the wiki at <http://wiki.cs.umb.edu/twiki/bin/view/TDWGImage/>
+
+## Scope
+
+A full task group may be expected to be concerned with the following topics, at least:
+
+* Descriptive content metadata
+* File formats, especially new standards such as JPEG2000
+* Standards for image LSID management and deployment
+* Best Practices for the acquisition, curation, and distribution of multimedia resources
+* Intellectual Property Rights
+* Outreach, e.g. workshops on image acquisition
+* Connections to other organizations involved with these topics to reduce duplication
+
+## Core Members
+
+The wiki has been inactive since St. Petersburg, so I list here only people I know to be active in image management research: 
+
+* Robert A. Morris (UMASS-Boston) 
+* Reed Beaman(Yale) 
+* Greg Riccardi (Florida State University) 
+* Stinger Guala (USDA PLANTS).
+
+## Clients
+
+Everybody concerned with any aspect of documenting the nature and occurence of organisms, and their behavior and interactions in biotic systems.
+
+## Outcomes and Outputs
+
+The formation of a full subgroup with an active wiki by June 1, 2007
+
+## Strategy
+
+This needs a good hook, because everybody takes a lot of pictures, and few people do anything systematic with them. So the core group---if it agrees to be such---needs to brainstorm about strategies and seek advice from the TDWG executive committee.
+
+## Resources
+
+<http://wiki.cs.umb.edu/twiki/bin/view/TDWGImage/>

--- a/content/pages/community/management.md
+++ b/content/pages/community/management.md
@@ -1,3 +1,36 @@
 title: Community management
 page_order: 101
 divider: above
+
+_Copied from <http://www.tdwg.org/activities/convener-responsibilities/>_
+
+Responsibilities of Conveners:
+
+1. Work with other potential stakeholders to draft the Interest or Task Group Charter and submit it for review by the Executive Committee. 
+    1. The charter must be clear and concise; this information will be public and therefore seen by potential members.
+    2. Charters should be reviewed annually and updated as necessary.
+    3. Template for [Interest](http://www.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/TDWG_Interest_Group_Charter_Template_03.doc) or [Task](http://www.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/TDWG_Task_Group_Charter_Template_03.doc) Group charter.
+2. Understand and use the online tools (URL) provided for group support. 
+    1. Ensure your home page reflects the activities and aspirations of the group. 
+    2. Reference a few concise articles, presentations or tutorials. 
+3. Ensure that the formation of the new group is announced. 
+    1. The Secretary should notify all members by email, a news item should be posted to the web site by the Convener and relevant mailing lists.
+4. Manage the group's activities:
+    1. Appointing members to specific roles to assist management and outcomes;
+    2. Scheduling meetings, emails, conference calls;
+    3. Securing funds to support the group's activities;
+5. Gain consensus in group activities.
+    1. TDWG standards are developed by consensus (URL), so ensure you develop skills to foster consensus.
+    2. Task Group Conveners should seek advice from the TAG to ensure that strategies are consistent with TDWG's overall approach to interoperability.
+6. Prepare annual report and brief presentations for the annual conference
+    1. An annual report is required from every Interest and Task Group. A [guide](http://www.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/guidance_docs/GuidetoInterestTaskGroupAnnualReporting.docx) and [template](http://www.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/InterestTaskGroupAnnualReport-Template--COPYTHISDOC.docx) for reports are available. 
+    2. A [PowerPoint template](http://www.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/Template_Conveners_Opening_Report.ppt) is provided for Interest and Task Group Conveners to provide a 5-minute report on the year's activities. 
+    3. A [PowerPoint template](http://www.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/Template_Conveners_Closing_Report.ppt) is provided for Interest Group and Task Conveners to provide a 5-minute report on issues for the year ahead.
+7. The TDWG Standards Process
+    1. When a draft standard is ready for submission, the Task Group Convener submits the standard to the Executive Committee via the Secretary.
+    2. The convener is responsible for managing responses in the review process.
+8. Interest Group Conveners are responsible for maintaining any standard produced by its Task Groups. This includes: 
+    1. Assessing the level of use (a standard without users must be deprecated).
+    2. Collating feedback and responding effectively when changes are required. 
+9. Upload archival material to the relevant site for the group's activities.
+    1. Documents and presentations should be archived as a permanent record of the group's deliberations and progress.

--- a/content/pages/community/ncd.md
+++ b/content/pages/community/ncd.md
@@ -1,1 +1,40 @@
 title: Natural collections descriptions interest group
+
+_Copied from <http://www.tdwg.org/activities/ncd/>_
+
+## Co-Conveners
+
+Alex Thompson -- godfoder [AT] acis [dot] ufl [dot] edu
+iDigBio, University of Florida, Gainesville, FL, USA
+
+Deb Paul -- dpaul [AT] fsu [dot] edu
+iDigBio, Florida State University, Tallahassee, FL, USA
+
+**Please note, this IG has recently been re-established. The co-conveners named above are current. The information below is dated. A new charter is in development. The most recent information is in the GitHub [repository](https://github.com/tdwg/ncd) and [wiki](https://github.com/tdwg/ncd/wiki). -- [TDWG Coordinator, 2017-02-08]**
+
+## Summary
+
+The Collections Descriptions Interest Group brings together work on collections descriptions being carried out for the European Union Framework VI programme known as SYNTHESYS and the work performed by RAVNS under the auspices of RLG with that carried out by TDWG members.
+
+Natural Collections Descriptions (NCD) covers all types of collections of natural history material; specimens, original artwork, photographs, archives, published material or a mixture.
+
+The Interest Group is developing NCD for use with RDF to ensure that it integrates with the TDWG common development architecture. The standard enables the aggregation of collections descriptions from many sources and facilitates resource discovery - particularly for collections that do not have a Web presence.
+
+NCD is a standard between the general resource discovery standards such as Dublin Core, and the rich collections description standards such as EAD. Mappings enable the extraction of a Dublin Core record from an NCD record or, conversely, filling out an NCD record into an EAD record.
+
+## Becoming Involved
+
+The Convener would be pleased to hear from anyone, and particularly:
+
+* those that have skills in the implementation of Web-based information systems, or
+* in writing descriptions based on interviews with collection owners, or
+* are owners of collections that would themselves like to test and make use of the standard and associated software, or
+* just having an interest in the use of collection descriptions in resource discovery systems.
+
+## Resources
+
+* The NCD Website is at: <http://www.tdwg.org/activities/ncd/>
+* Mailing list discussions have been merged into TDWG-content: <http://lists.tdwg.org/mailman/listinfo/tdwg-content>
+* Discussion and documents are on the Wiki: <http://wiki.tdwg.org/twiki/bin/view/NCD/WebHome>
+
+<https://github.com/tdwg/wiki-archive/tree/master/twiki/data/NCD>

--- a/content/pages/community/osr.md
+++ b/content/pages/community/osr.md
@@ -1,1 +1,28 @@
 title: Observations & specimens interest group
+
+_Copied from <http://www.tdwg.org/activities/osr/>_
+
+## Convenor
+
+Steve Kelling
+Cornell Lab of Ornithology
+Cornell University
+158 Sapsucker Woods Rd.
+Ithaca NY 14850
+Email: stk2(at)cornell.edu
+Phone: 607-254-2478
+
+## Summary
+
+Most primary biodiversity data is based on observational data, which consists of observer-derived measurements of organisms in the environment, or specimens collected in the environment and stored within Natural History collections. There is sufficient overlap in the information stored in observational data and specimen records to allow existing data standards to integrate these data types. However, specific data types have unique requirements that need to be addressed. The purpose of this Interest Group is to explore concepts and methods of biodiversity data description, integration and transfer that fully integrate specimen and observational data into existing data exchange schemas.
+
+## Becoming Involved
+
+* Anyone with and interest in organizing observational and specimen data can be involved.
+* Contact Steve Kelling (stk2(at)cornell.edu)
+
+## Resources
+
+* [Access to Biological Collections Data (ABCD) Task Group Website](http://www.tdwg.org/activities/abcd/)
+* [Darwin Core Task Group Website](http://www.tdwg.org/activities/darwincore/)
+* [Observational Data Task Group Wiki](http://wiki.tdwg.org/Observational/)

--- a/content/pages/community/paleo.md
+++ b/content/pages/community/paleo.md
@@ -1,1 +1,59 @@
 title: Paleobiology interest group
+
+_Copied from <https://github.com/tdwg/paleo/blob/master/charter.md>_
+
+## Convenor
+
+Denné Reed
+Dept. of Anthropology
+University of Texas at Austin
+2201 Speedway Stop C3200
+Austin, TX 78712
+reedd [AT] austin [dot] utexas [dot] edu
+<http://paleocore.org>
+
+## Core Members
+
+* Mark D. Uhen, George Mason University, Paleobiology Database
+* Ann Molineaux, University of Texas at Austin
+* Edward Davis, University of Oregon Museum of Natural and Cultural History
+* Michael McClennen, Paleobiology Database
+* James Klaus, University of Miami
+* Kathy Hollis, National Museum of Natural History
+* Jessica Theodor, University of Calgary
+* David Lazarus, Museum für Naturkunde, Berlin
+
+## Motivation
+
+The motivation of this interest group is to broaden the application of existing standards, such as Darwin Core and ABCD, to accommodate the large community of paleobiologists and paleobiological data now coming online. The group also seeks to broaden the adoption of data standards and data management best practices within pale biology by improving documentation, providing examples and simplifying the use of data standards.
+
+Paleobiological data span a broad range of taxonomic, geographic and temporal frames, and they are interconnected with many related domains of knowledge including climatology, geochemistry, stratigraphy, and geochronology. The Paleo interest group also seeks to network with similar efforts in related domains.
+
+The group is particularly interested in developing formal ontologies and other Semantic Web technologies in order to allow the consistent applications of concepts and relationships in paleobiology. The goal is not to impose conceptual frameworks on the domain but rather to provide a well-conceived framework that members of the community can draw upon, modify or enhance if they choose. A related goal is to utilize the institutional framework of the TDWG as a mechanism for proposing, reviewing and ratifying these concepts (more) impartially and judiciously.
+
+## Becoming Involved
+
+All members of the TDWG and paleobiology community are invited to participate in the activities of the Paleo interest group by contributing ideas for new terms, comments on proposed terms, ideas for ontology development and conceptual frameworks for data sharing in paleobiology _sensu lato_.
+
+The working group seeks input from domain specialists across the varied areas of paleobiology including, vertebrate and invertebrate paleontology, paleobotony, palynology, micropaleontology etc. The group also invites the participation of experts from cognate domains such as geochronology, stratigraphy, geochemistry, biogeography, systematics and paleoclimate.
+
+The group further seeks the expertise of ontologists and information scientists in the activity of data modelling and developing formal ontologies.
+
+The group meets online twice annually and those interested in participating should contact the interest group convener.
+
+## History/Context
+
+The Darwin Core standard currently incorporates terms specific to paleobiology, many of which were introduced by a previous effort, the DarwinCope project. DarwinCope generated useful extensions that allow Darwin Core to be applied by paleobiology data interchange projects.
+
+The goal of the new interest group is to continue and extend the productive work of DarwinCope by further developing new ideas as the needs and capacities of paleobiology community mature. The past decade has seen burgeoning efforts at data integration and synthesis, many linked to NSF funded cyber-infrastructure initiatives such as Earth Cube. Darwin Core and the TDWG are a natural fit for the further development of data standards in paleobiology. This interest groups seeks to leverage the existing infrastructure of TDWG for the study of paleobiology along side extant biodiversity.
+
+Similarly the ABCDEFG is a geosciences extension of the ABCD data standard. The Paleobiology Interest Group will work maintain compatibility between paleobiology initiatives in Darwin Core and ABCDEFG. 
+
+## Summary
+
+Biodiversity is much more than the catalogue of living life. It includes the record of past life bound up in the fossil record. Incorporating paleobiological data into investigations of biogeography, biodiversity, speciation and ecology radically expands the scope of our understanding about organic evolution and biological processes. Yet paleobiological data also introduce new complexities and uncertainties. For example, geochronology becomes an entirely new and complex dimension of data that must be managed. Additionally, geospatial, taxonomic, systematic and phylogenetic assertions become more challenging when dealing with paleobiological data. Additionally, paleobiologists rely on the integration of a multiplicity of data sources and this can only be accomplished with drastic improvements in the data exchange protocols. Biodiversity standards such as Darwin Core play a critical role in paleobiology, but there remain many aspects of the existing standards, in their current instantiation, that do not capture the breadth of information involved in paleobiology nor the peculiarities of fossil data. The Paleo interest group within TDWG is established to address the particular needs of paleobiological data by developing extensions and refinements to existing standards. A beneficial by-product of this effort is greater intellectual exchange and collaboration between paleobiologists and neontologists. 
+
+## Resources
+
+* This repository. Create a GitHub account and follow the repository. If you'd like to contribute, ask the convener to make you a collaborator.
+* Also see the [PaleoCore website](http://paleocore.org).

--- a/content/pages/community/process.md
+++ b/content/pages/community/process.md
@@ -1,1 +1,93 @@
 title: Process interest group
+
+_Copied from <http://www.tdwg.org/activities/process/>_
+
+## Convener
+
+Stan Blum - TDWG Coordinator (stanblum(at)gmail.com)
+
+## Purpose
+
+The Process subgroup will draft new bylaws[^1] for TDWG, which will specify how standards are developed, documented, reviewed, revised, and approved. To the extent that the revised bylaws require changes to the organizational structure of TDWG, the Process subgroup will draft new articles of the TDWG Constitution, which will specify how the new entities are to be formed and maintained, and what their roles will be.
+
+In addition, the Process group may draft companion documents to recommend how entities within TDWG conduct business so as to improve effectiveness and communications within and beyond TDWG.
+
+The revised bylaws are intended to improve the speed and efficiency of standards development, as well as the quality and integration of standards.
+
+[1]: Merriam-Webster dictionary defines bylaw [one word] as: a rule adopted by an organization chiefly for the government of its members and the regulation of its affairs. Other IT standards bodies do not refer to their standards development process as “bylaws”, but we use the term in this charter for continuity. This use does not imply a decision to continue use beyond this document.
+
+## Background
+
+The existing TDWG process (Bylaws; <http://www.tdwg.org/constitution.html#bylaws>) were written before the Internet had become such a large part of scientific information management and interchange. As Internet technologies become an ever deeper part of science infrastructure, the demand for biodiversity information interchange becomes ever greater. TDWG must attract and engage more participants, become more efficient in developing high-quality and consistent standards, and improve its capacity to communicate its purposes, methods, and products to biodiversity information managers. Some of TDWG’s scaling and efficiency problems can be corrected by appropriate communication technologies, but other solutions must rely on social practice. We are revising the bylaws in order to make the desired social practices more uniform across working groups and independent of the particular person fulfilling a role.
+
+This project to revise the TDWG process is being undertaken as part of a larger project to strengthen TDWG as a standards development organization. Several documents have been drafted to provide background for the larger effort, some of which are intended to provide background for revising the process. These documents analyze the existing process and describe the standards development processes used in larger, more modern organizations. These documents are currently at:
+
+<http://www.tdwg.gbif.org/subgroups/tip/tip-document-archive/>
+
+The most important to read are:
+
+* TDWG_Existing_Processes.doc
+* TDWG_Best_Current_Practice.doc
+* TDWG_Documentation_Strategy.doc
+* TDWG_Documentation_Priorities_2006.doc
+
+## Scope
+
+Issues that are likely to be addressed within this work include:
+
+* the responsibilities of existing and new officers and organizational entities within TDWG;
+* the evolution of standards along a track or lifecycle, and the criteria (triggers) for advancement
+* the versioning of standards and drafts of standards
+* the maintenance of “mature” standards
+* the functions or requirements for an electronic repository of TDWG standards and related documents
+
+## Core Members
+
+* Stan Blum (sblum(at)calcademy.org) 
+* Lee belbin (lee(at)tdwg.org) 
+* John Wieczorek (tuco(at)berkeley.edu) 
+* Mark Jackson (m.jackson(at)rbgkew.org.uk) 
+
+## Clients
+
+* TDWG “officials” -- anyone managing TDWG business
+* TDWG members and participants
+* Biodiversity information managers
+* Anyone needing information about the authority behind a TDWG standard
+
+## Outcomes and Outputs
+
+1. Preliminary meeting at TDWG 2005 St Petersburg (September 2005: Done)
+2. Draft 1 of the Process subgroup charter (November 2005: Done)
+3. First subgroup meeting (January 2006: Done)
+4. Draft of the new process documents which include
+    1. new constitution
+    2. New process
+    3. Charter template (February 2006)
+5. Final version of the new process documents (April 2006)
+6. Approval of the new process (June 2006)
+
+## Strategy
+
+Our guiding objectives are to create a specification that is:
+
+1. explicit enough to guarantee the quality and effectiveness of TDWG standards,
+2. general enough to accommodate the known variety of types of standards,
+3. flexible enough to accommodate a variety of work practices that might be used or required in creating a standard, and
+4. light enough not to impose undue (bureaucratic) burdens.
+ 
+The work process will include the following steps
+
+1. Examine the existing TDWG process as well as practices in similar standards organisations
+2. Outline new TDWG process and companion (explanatory) documents and request comments from Process Subgroup members,
+3. Incorporate comments and publish full draft of the new TDWG Process as well as drafts for revised Articles of TDWG Constitution, with requests for comment
+4. Summarize and incorporate comments
+5. Submit New TDWG Process to TDWG membership for approval
+
+## Resources
+
+Web: <http://www.tdwg.gbif.org/subgroups/process/>
+
+Wiki: <http://wiki.tdwg.org/twiki/bin/view/Process/WebHome>
+
+Mail List: <http://lists.tdwg.org/mailman/listinfo/tdwg-process>

--- a/content/pages/community/services.md
+++ b/content/pages/community/services.md
@@ -1,1 +1,63 @@
 title: Biodiversity services and clients interest group
+
+_Copied from <http://www.tdwg.org/activities/biodiversity-services-clients/charter/>_
+
+## Conveners
+
+James Macklin
+Research Scientist
+Botany and Biodiversity Informatics
+Agriculture and Agri-Food Canada
+Ottawa, Ontario, Canada
+james.macklin [at] agr.gc.ca
+
+Anton Güntsch
+Head, Research & Development Group Biodiversity Informatics
+Freie Universität Berlin
+Botanic Garden and Botanical Museum Berlin-Dahlem
+Germany
+a.guentsch [at] bgbm.org
+
+Niall Beard
+Scientific Web Technologist
+University of Manchester, School of Computer Science
+United Kingdom
+niall.beard [at] manchester.ac.uk
+
+## Core Members
+
+* David Fichtmüller (d.fichtmueller [at] bgbm.org)
+* Dominik Röpert (d.roepert [at] bgbm.org)
+* Maren Gleisberg (m.gleisberg [at] bgbm.org)
+* Andreas Müller (a.mueller [at] bgbm.org)
+* Andreas Kohlbecker (a.kohlbecker [at] bgbm.org)
+* Paul Morris (mole [at] morris.net)
+* Bertram Ludäscher (ludaesch [at] gmail.com)
+* Florian Jansen (jansen [at] uni-greifswald.de)
+* Alan Williams (alan.r.williams [at] manchester.ac.uk )
+* Aleksandra Nenadic (a.nenadic [at] manchester.ac.uk)
+* Norman Morrison (norman.morrison [at] manchester.ac.uk)
+
+## Motivation
+
+The aim of the Biodiversity Services and Clients Interest Group (BSCI) is to promote improved interoperability of biodiversity web services through common service API design principles, recognition of the needs of client systems, harmonized and machine-readable service documents, and a joint service registration system for promotion and discovery purposes as well as service monitoring. Over the last 15 years, the biodiversity informatics community underwent a fundamental technological shift from database-driven, human-readable web portals to service infrastructures for machine-to-machine communication. However, many of the new service layers have been designed in isolation and were not conceived as standardised and reliable functional units in a global biodiversity service-oriented infrastructure.
+
+The Interest Group will continuously assess the biodiversity service infrastructure landscape and coordinate a harmonisation process for service APIs and their documentation. An important focus will be the analysis of criteria for service usability in integrating systems (e.g. workflow environments such as Kepler and Taverna), stability and versioning of service APIs, as well as semantic interoperability.
+
+## Becoming Involved
+
+The BSCI group is open to all interested parties. Members should actively participate in group discussions and be willing to apply results of the harmonisation process to analytical tool and data set services they may be providing to international infrastructures. Membership can be requested from the interest group conveners.
+
+## History and Context
+
+The conveners hosted a Biodiversity Services and Workflow Symposia at the TDWG annual conference in 2013 (Florence) and 2014 (Jönköping) and received a lot of interest from the participants. Both Symposia concluded that improved standardisation and documentation of biodiversity informatics services is urgently needed to avoid uncoordinated development of service APIs worldwide and to enable the development of a new generation of data-driven research platforms and workflows. The participants agreed that a concerted approach in the form of a TDWG interest group would carry forward the process effectively.
+
+## Summary
+
+The aim of the Biodiversity Services Interest Group (BSCI) is to assess usefulness of existing biodiversity web service infrastructures from the perspective of integrating software applications such as workflow environments, discuss and agree upon common principles for API design, stability and documentation,  encourage registration of useful Web services in a well-founded, well-known community directory i.e. BiodiversityCatalogue, produce documentation including  background material, guidelines and best practices. The group will actively collaborate with projects and initiatives with similar aims (e.g. BioVeL, GFBio, LifeWatch, Kurator). Members will actively promote the findings in external conferences and workshops and encourage service developers to adopt agreed upon  API principles and to document and advertise services in joint registry systems.
+
+## Resources
+
+BSCI Service Registry: <http://www.biodiversitycatalogue.org>.
+
+BSCI homepage, wiki, and document repository will be made available via the TDWG website.

--- a/content/pages/community/species.md
+++ b/content/pages/community/species.md
@@ -1,1 +1,41 @@
 title: Species information interest group
+
+_Copied from <http://www.tdwg.org/activities/species-information/charter/>_
+
+## Convenor
+
+Francisco Pando
+
+Real Jardín Botánico - CSIC
+Plaza de Murillo228014
+Madrid, Spain
+
+email Francisco Pando pando [AT] rjb [dot] csic [dot] es
+
+## Summary
+
+The goal of the group is to discuss and find shared understanding on how to represent "Species information" for electronic dissemination, exchange and integration.
+
+By "Species Information" we refer to all kinds of properties or traits related to taxa, including those related to descriptions, legal, conservation, management, demographics, nomenclatural, related resources, etc. In this regard this group interest's goes beyond descriptions.
+
+Having this focus, this interest group will touch upon and interact with other TDWG's groups such as the Biological Descriptions IG or the Imaging IG.
+
+Sharing species information is not only about exchanging information among peers; how to present "science-grade" to a non-specialize public in an effective way is a concern of the founding members of this group and also an area for discussion here. 
+
+This group, open to all interested parties, originates from mainly from two current initiatives "Encyclopedia of Life" and "Plinian Core Group".
+
+## Becoming Involved
+
+There are numerous projects around the world that aims to respond to the demand for "species information". Many of the elements sought and produced within these initiatives could be effectively re-used if there were a common language and a framework. This interest group is established to advance these common components. 
+
+All interested parties are encouraged to become involved with the interest group or specific task groups. Membership of this group is open. If you work with species, involved in creation or editing of digital flora or faunas, species pages-- whether these are generalized or specialized (legal, conservation, management, etc.), mash-ups around species -- and you would like to share your data with others, TSI may need your contribution.
+
+Please contact the convener or any core member about how to become involved. 
+
+The TDWG process requires that new Task Groups be launched through an Interest Group. The Species Information group can facilitate establishment of new Task Groups that relate to Species Information standards. Please contact the convenor to discuss potential projects or join existing Task Groups.
+
+## Resources
+
+* Website: <https://github.com/PlinianCore>
+* Wiki: <https://github.com/PlinianCore/Documentation/wiki>
+* Mailing List: please subscribe to the repositories on GitHub, or use "[tdwg-content](http://lists.tdwg.org/mailman/listinfo/tdwg-content)" for subject related issues, and "[tdwg-tag](http://lists.tdwg.org/mailman/listinfo/tdwg-tag)" for any technical issues.

--- a/content/pages/community/support.md
+++ b/content/pages/community/support.md
@@ -1,2 +1,57 @@
 title: Community support
 page_order: 102
+
+*Copied from <http://www.tdwg.org/activities/comm-support-fund/>*
+
+## Call for TDWG CSF Proposals (Call ID: 1701)
+
+* Proposals must be submitted by Interest or Task Group Conveners using the [form for CSF 1701 proposals](http://goo.gl/forms/ksAbIC0tTj4Tx4dY2).
+* **Deadline for proposals under this call (1701): April 10, 2017**
+
+Please be aware that proposals from Groups that have a current annual report will be given preference. Instructions and a template for IG/TG annual reports is linked under item 6 on the [Convener Responsibilities](http://www.tdwg.org/activities/comm-support-fund/activities/convener-responsibilities/) page. See the description of the CSF program below.
+
+## What is the TDWG Community Support Fund?
+
+TDWG Interest (IG) and Task (TG) Groups undertake the core business of developing, maintaining, and integrating biodiversity information standards. TDWG is committed to supporting the work of IG and TG, by contributing to the costs of conducting working meetings. Support is provided through a fund dedicated to this purpose, the TDWG Community Support Fund (CSF). The size of the Fund is adjusted yearly by decision of the TDWG Executive Committee.
+
+## What does the TDWG CSF cover?
+
+1. Travel and subsistence support for participation in IG/TG working meetings.
+2. Costs directly related to the organization of IG/TG working meetings, including venue hire.
+3. Costs related to the dissemination of the workshop/meeting results and engagement of stakeholders.
+
+## Who can apply?
+
+TDWG IG/TG conveners may apply for funds to (co-)organize IG/TG working meetings.
+
+## Call frequency
+
+Provided that sufficient resources are available, a call for applications will be announced at least once every calendar year.
+
+## Criteria for awarding TDWG CSF
+
+1. Previous activity of the Group, proven through annual reports submitted to the TDWG Executive Committee or other public reports and products (not applicable to new Groups*)
+2. Overall impact, timeliness and cost efficiency
+3. Inclusiveness of the participation model (e.g., percentage of new members participating and geographic coverage)
+4. Expected progress on development of new or revision of current TDWG standards
+5. Availability of matching funds from other sources (as percentage of total costs)
+
+_New Groups are here defined as formally endorsed IG and TG with less than a year's activity from the time of approval._
+
+**Additional information and restrictions**
+
+The maximum amount of funds awarded per proposal is USD $3,000.
+
+Following successful completion of TDWG CSF-supported working meetings, the I/G Convener must report to the TDWG Executive Committee key outputs and action items. Reports must be submitted within 30 days after the event date.
+
+## Review and scoring process
+
+Applications received by the deadline will be reviewed by TDWG Executive Committee and evaluated against the criteria set forth in the call (see section 5). Following the completion of the review, applicants will be notified of their scores and the Committee's decision. Successful proposals will be communicated to the TDWG membership and posted on the TDWG website.
+
+## Application form
+
+Application forms will be available online at URLs provided in the announcement of each call.
+
+## Funding mechanism
+
+Proposals must include an estimated budget. Following an award, the budget will be finalized by agreement with the TDWG Treasurer. Generally, funds will be disbursed to participants as reimbursement of expenses incurred. Receipts and/or reimbursement forms must be submitted to the TDWG Treasurer within 30 days of the event. By prior arrangement, vendors may submit invoices directly to the Treasurer.

--- a/content/pages/conferences.md
+++ b/content/pages/conferences.md
@@ -1,5 +1,5 @@
 title: Conferences
-page_order: 4
+page_order: 3
 
 ## Next conference
 

--- a/content/pages/standards.md
+++ b/content/pages/standards.md
@@ -1,5 +1,5 @@
 title: Standards
-page_order: 2
+page_order: 1
 
 * TDWG Standards Documentation Standard
 * Vocabulary Maintenance Standard

--- a/content/pages/standards.md
+++ b/content/pages/standards.md
@@ -1,16 +1,34 @@
 title: Standards
 page_order: 1
 
-* TDWG Standards Documentation Standard
-* Vocabulary Maintenance Standard
-* Audubon Core Multimedia Resources Metadata Schema
-* GUID and Life Sciences Identifiers Applicability Statements
-* Darwin Core
-* TAPIR - TDWG Access Protocol for Information Retrieval
-* Access to Biological Collection Data - version 2.06
-* Structured Descriptive Data
-* Taxonomic Concept Transfer Schema
-* Definition of the Delta Format
-* Natural Collections Descriptions (NCD): A data standard for exchanging data describing natural history collections
-* ABCDDNA - DNA extension for Access to Biological Collection Data
-* Prior standards
+_Copied from <http://www.tdwg.org/standards/>_
+
+TDWG's standards are listed below. For information about current work within TDWG, we would suggest that you look at the page linked in the Activity column or the [Activities page](http://www.tdwg.org/http://www.tdwg.org/activities/). For further information, please [contact us](http://www.tdwg.org/about-tdwg/contact-us/).
+
+Title | Activity | Category | Status | Date Published
+--- | --- | --- | --- | ---
+[TDWG Standards Documentation Standard](http://www.tdwg.org/standards/147) | [Vocabulary Maintenance Specification Task Group](https://github.com/tdwg/vocab) | Technical Specification | Current | 25-Apr-2017
+[Vocabulary Maintenance Standard](http://www.tdwg.org/standards/642) | [Vocabulary Maintenance Specification Task Group](https://github.com/tdwg/vocab) | Best Current Practice | Current | 25-Apr-2017
+[Audubon Core Multimedia Resources Metadata Schema](http://www.tdwg.org/standards/638) | [Multimedia Resources Task Group](http://www.tdwg.org/activities/img/multimedia/) | Technical Specification | Current | 28-Oct-2013
+[GUID and Life Sciences Identifiers Applicability Statements](http://www.tdwg.org/standards/150) | [Technical Architecture Group](http://www.tdwg.org/activities/tag/) | Applicability Statements | Current | 30-Jan-2011
+[Darwin Core](http://www.tdwg.org/standards/450) | [DarwinCore Task Group (DwC)](http://www.tdwg.org/activities/darwincore/) | Technical Specification | Current | 09-Oct-2009
+[TAPIR - TDWG Access Protocol for Information Retrieval](http://www.tdwg.org/standards/449) | [TAPIR Task Group](http://www.tdwg.org/activities/tapir/) | Technical Specification | Current | 09-Sep-2009
+[Access to Biological Collection Data - version 2.06](http://www.tdwg.org/standards/115) | [Access to Biological Collections Data](http://www.tdwg.org/activities/abcd/) | Technical Specification | Current (2005) | 16-Sep-2005
+[Structured Descriptive Data](http://www.tdwg.org/standards/116) | [Biological Descriptions Interest Group](http://www.tdwg.org/activities/bd/) | Technical Specification | Current (2005) | 16-Sep-2005
+[Taxonomic Concept Transfer Schema](http://www.tdwg.org/standards/117) | [Taxonomic Names and Concepts Interest Group](http://www.tdwg.org/activities/tnc/) | Technical Specification | Current (2005) | 16-Sep-2005
+[Definition of the Delta Format](http://www.tdwg.org/standards/107) | | Technical Specification | Current (2005) | 01-Oct-1986
+[Natural Collections Descriptions (NCD): A data standard for exchanging data describing natural history collections](http://www.tdwg.org/standards/312) | [Natural Collections Descriptions Interest Group](http://www.tdwg.org/activities/ncd/) | Technical Specification | Draft | 
+[ABCDDNA - DNA extension for Access to Biological Collection Data](http://www.tdwg.org/standards/640) | [Access to Biological Collections Data](http://www.tdwg.org/activities/abcd/) | Technical Specification | Draft | 
+[HISPID3 - Herbarium Information Standards and Protocols for Interchange of Data](http://www.tdwg.org/standards/110) | [Observation and Specimen Records](http://www.tdwg.org/activities/osr/) | Technical Specification | Prior | 01-Oct-1996
+[Economic Botany Data Collection Standard](http://www.tdwg.org/standards/103) | Economic Botany Interest Group | Best Current Practice | Prior | 01-Oct-1995
+[Plant Occurrence and Status Scheme](http://www.tdwg.org/standards/106) | | Status and Categories | Prior | 01-Oct-1995
+[Plant Names in Botanical Databases](http://www.tdwg.org/standards/113) | | Best Current Practice | Prior | 01-Oct-1995
+[Authors of Plant Names](http://www.tdwg.org/standards/101) | | Status and Categories | Prior | 01-Oct-1992
+[World Geographical Scheme for Recording Plant Distributions](http://www.tdwg.org/standards/109) | | Status and Categories | Prior | 01-Oct-1992
+[XDF - A Language for the Definition and Exchange of Biological Data Sets](http://www.tdwg.org/standards/108) | | Technical Specification | Prior | 01-Oct-1991
+[Botanico-periodicum-huntianum/supplementum](http://www.tdwg.org/standards/114) | | Status and Categories | Prior | 01-Oct-1991
+[Index Herbariorum. Part I: The Herbaria of the World](http://www.tdwg.org/standards/105) | | Status and Categories | Prior | 01-Oct-1990
+[International Transfer Format for Botanic Garden Plant Records](http://www.tdwg.org/standards/102) | | Technical Specification | Prior | 01-Oct-1987
+[Floristic Regions of the World](http://www.tdwg.org/standards/104) | | Status and Categories | Prior | 01-Oct-1986
+[Taxonomic Literature, ed. 2 and its Supplements](http://www.tdwg.org/standards/111) | | Status and Categories | Prior | 01-Oct-1976
+[Botanico-periodicum-huntianum](http://www.tdwg.org/standards/112) | | Status and Categories | Prior | 01-Oct-1970

--- a/content/pages/standards.md
+++ b/content/pages/standards.md
@@ -14,4 +14,3 @@ page_order: 1
 * Natural Collections Descriptions (NCD): A data standard for exchanging data describing natural history collections
 * ABCDDNA - DNA extension for Access to Biological Collection Data
 * Prior standards
-

--- a/settings.py
+++ b/settings.py
@@ -112,10 +112,11 @@ GITHUB_URL = "https://github.com/tdwg/website"
 # To hide pages from the navigation, add "status: hidden" in their metadata. Note that doing so 
 # for a parent page, will make all its children top level pages!
 
-# Pages are ordered by their filename. This can be overwritten by adding "page_order: integer" to 
-# their metadata. The plugin "pelican-page-order" allows to set this only where necessary (rather 
-# than on every page).
+# Pages are ordered by their title. This can be overwritten by adding "page_order: integer" to their
+# metadata. The plugin "pelican-page-order" allows to set this only where necessary (rather than on 
+# every page).
 
+PAGE_ORDER_BY = "title"
 DISPLAY_CATEGORIES_ON_MENU = False
 DISPLAY_PAGES_ON_MENU = True
 MENUITEMS = [


### PR DESCRIPTION
To give some body to the current pages, I've copied the content from the old website to those pages. This is just a point to start from: text has to be adapted (extensively sometimes) and many links won't work. The fact that content is just copied is indicated at the top of each page, e.g.:

> _Copied from <http://www.tdwg.org/activities/>_

Copied:

* Table with standards
* Community = Activities
* Relevant IG
* Community management = Convener responsibilities
* Community support = Comm. support fund
* About
* Executive committee
* Constitution
* FS
* Contact

Not (yet) copied:

* Home
* Standard pages
* Conferences pages/subwebsites
* Task groups
* Membership
* Press resources
* News articles
