### PR TITLE
Change Audubon Core landing page to conform to Standards Documentation Specification

### DIFF
--- a/content/pages/standards/ac/index.md
+++ b/content/pages/standards/ac/index.md
@@ -37,6 +37,3 @@ Audubon Core is maintained by a specialized [Interest Group](http://www.tdwg.org
 The activities of the AC Maintenance Group are documented at the group's Github repository, https://github.com/tdwg/ac, where a current list of core members and their contact information can be found.  Community participation is welcome.  If you would like to participate in this group, contact the convener or one of the core members.  
 
 To participate in the communications of the group, "watch" the group's [Issues tracker](https://github.com/tdwg/ac/issues).  This issues tracker is the mechanism for suggesting specific changes to the standard as well as to raise issues for discussion by the group.
-
-
-/638/)

--- a/content/pages/standards/ac/index.md
+++ b/content/pages/standards/ac/index.md
@@ -1,6 +1,6 @@
 ---
 title: Audubon Core
-summary: 
+summary:
 cover_image: https://images.unsplash.com/photo-1430990480609-2bf7c02a6b1a
 cover_image_by: Mikhail Vasilyev
 cover_image_ref: https://unsplash.com/photos/gGC63oug3iY
@@ -8,37 +8,35 @@ tags: technical specification, current standard, 2013
 github: https://github.com/tdwg/ac
 ---
 
-# AudubonCore (AC)
+**Title:** Audubon Core Multimedia Resources Metadata Schema
 
-The Audubon Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
+**IRI to be cited and linked:** http://www.tdwg.org/standards/638
+
+**Publisher:** [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+**Status:** Current Standard
+
+**Ratified:** 2013-10-28
+
+**Abstract:** The Audubon Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
+
+**Preferred citation:** GBIF/TDWG Multimedia Resources Task Group. 2013. Audubon Core Multimedia Resources Metadata Schema. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/638
+
+## Parts of the standard
+
+The Audubon Core standard is comprised of one vocabulary, the Audubon Core basic vocabulary (http://rs.tdwg.org/ac/), and four documents:
+- [Audubon Core Introduction](https://tdwg.github.io/ac/introduction) (http://rs.tdwg.org/ac/doc/introduction/) - a brief introduction to the standard
+- [Audubon Core Structure](https://tdwg.github.io/ac/structure) (http://rs.tdwg.org/ac/doc/structure/) - the normative description of the structure of Audubon Core
+- [Audubon Core Term List](https://tdwg.github.io/ac/termlist) (http://rs.tdwg.org/ac/doc/termlist/) - a complete list of terms included in Audubon Core, with their normative definitions
+- [Audubon Core Guide](https://tdwg.github.io/ac/guide) (http://rs.tdwg.org/ac/doc/guide/) - a more detailed guide to the aims and uses of the vocabulary
 
 ## The Audubon Core Maintenance Group
 
-Audubon Core is maintained by a specialized [Interest Group](http://www.tdwg.org/about-tdwg/process/) whose [charter](https://github.com/tdwg/ac/blob/master/audubon-core_maintenance-group_charter.md) was approved in January 2018. The functions of the Audubon Core Maintenance Group are described in detail in [Section 2 of the TDWG Vocabulary Maintenance Specification](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md#2-administration). In brief, the Maintenance Group manages vocabulary term additions and changes, and maintains the documentation that helps users to understand and apply the standard. As an Interest Group, it may establish Task Groups to accomplish broader changes to the standard. 
+Audubon Core is maintained by a specialized [Interest Group](http://www.tdwg.org/about-tdwg/process/) whose [charter](https://github.com/tdwg/ac/blob/master/audubon-core_maintenance-group_charter.md) was approved in January 2018. The functions of the Audubon Core Maintenance Group are described in detail in [Section 2 of the TDWG Vocabulary Maintenance Specification](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md#2-administration). In brief, the Maintenance Group manages vocabulary term additions and changes, and maintains the documentation that helps users to understand and apply the standard. As an Interest Group, it may establish Task Groups to accomplish broader changes to the standard.
 
-## Core Members of the AC Maintenance Group
+The activities of the AC Maintenance Group are documented at the group's Github repository, https://github.com/tdwg/ac, where a current list of core members and their contact information can be found.  Community participation is welcome.  If you would like to participate in this group, contact the convener or one of the core members.  
 
-Currently, core members of the group are:
+To participate in the communications of the group, "watch" the group's [Issues tracker](https://github.com/tdwg/ac/issues).  This issues tracker is the mechanism for suggesting specific changes to the standard as well as to raise issues for discussion by the group.
 
-Steve Baskauf - Vanderbilt University Department of Biological Sciences (Convener) - [steve.baskauf@vanderbilt.edu](mailto:steve.baskauf@vanderbilt.edu)
 
-Robert A. Morris - University of Massachusetts, Boston - [morris.bob@gmail.com](mailto:morris.bob@gmail.com)
-
-Douglas Boyer -Department of Evolutionary Anthropology, Duke University, Director of MorphoSource open access 3D repository - [douglasmb@gmail.com](mailto:douglasmb@gmail.com)
-
-Niels Klazenga - Royal Botanic Gardens Victoria - [Niels.Klazenga@rbg.vic.gov.au](mailto:Niels.Klazenga@rbg.vic.gov.au)
-
-Rebecca Snyder - Smithsonian Institution, National Museum of Natural History - [SNYDERR@si.edu](mailto:SNYDERR@si.edu)
-
-## Participating in the Group
-
-If you would like to participate in this group, contact the convener or one of the core members. 
-
-To participate in the communication system of the group, "watch" the group's [Issues tracker](https://github.com/tdwg/ac/issues). This issues tracker is the mechanism for suggesting specific changes to the standard as well as to raise issues for discussion by the group.
-
-## Documentation
-
-See [http://terms.tdwg.org/wiki/Audubon_Core](http://terms.tdwg.org/wiki/Audubon_Core) for links to normative and non-normative documentation. Audubon Core is an adopted standard of TDWG.
-
-Cite as Morris, Robert A., et al. 2014. Audubon Core Multimedia Resources Metadata Schema, Release 1.0. Biodiversity Information Standards (TDWG) [http://www.tdwg.org/standards/638/](http://www.tdwg.org/standards/638/)
-
+/638/)


### PR DESCRIPTION
@peterdesmet:   [Section 3.1 of the Standards Documentation Specification](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md#31-landing-page-for-the-standard) states how the landing page for a standard should be laid out.  I've gone through the existing AC landing page on the website and edited it so that it conforms with the requirements of section 3.1 .  

The new landing page also contains links to the four newly revised AC documents.  The names of the documents are hyperlinked to the actual URLs of those pages at github.io rathern than to the page permanent URIs (which aren't currently set up to dereference but that's not a problem we are going to fix here).  

@stanblum and I had a conversation earlier about whether the group's Github repo page should be the landing page for the standard, or whether it should be the page about the standard on the TDWG website.  It seems clear to me that the landing page should be the one on the TDWG website, since it will be relatively stable.  In contrast, the github repo page will change all the time as the group carries out its activities.  So I think it makes sense for this page to be the actual "landing page" as specified in the SDS.

So one feature that needs to be implemented after these page edits are incorporated is to fix the redirect for the standard's permanent URI (http://www.tdwg.org/standards/638) so that it points to this web page and not to the groups github repo README.md page.