### PR TITLE
Update the yellow box on homepage

### DIFF
--- a/content/pages/home/index.md
+++ b/content/pages/home/index.md
@@ -10,8 +10,8 @@ url: index.html
 save_as: index.html
 template: page_home
 alert_title: TDWG 2018
-alert_text: Subscriptions to the TDWG 2018 Annual Conference are now open.
-alert_button: Register now
+alert_text: Thank you for attending the SPNHC+TDWG 2018 Conference!
+alert_button: Visit the conference website
 alert_link: http://spnhc-tdwg2018.nz/
 alert_image: https://images.unsplash.com/photo-1508068235022-85a3716679b7
 newsletter_title: Keep up to date with TDWG


### PR DESCRIPTION
No longer "Subscriptions are now open", but "Thank you for attending the SPNHC+TDWG 2018 Conference!" At first I though to link to the abstracts: https://biss.pensoft.net/collection/62/ but I think that the best entry point is still the conference website.

<img width="310" alt="screen shot 2018-08-31 at 14 24 01" src="https://user-images.githubusercontent.com/600993/44889328-89163b00-ad29-11e8-81b8-79efcf425d7a.png">
