### PR TITLE
fixed broken links to GUID and LSID AS

### DIFF
--- a/content/pages/standards/guid-as/index.md
+++ b/content/pages/standards/guid-as/index.md
@@ -12,7 +12,7 @@ github: https://github.com/tdwg/guid-as
 
 ## GUID applicability statement
 
-The [TDWG Globally Unique Identifiers (GUID) applicability statement](guid/tdwg_guid_applicability_statement.pdf):
+The [TDWG Globally Unique Identifiers (GUID) applicability statement](https://github.com/tdwg/guid-as/blob/master/guid/tdwg_guid_applicability_statement.pdf):
 
 1. Provides guidance on how to use GUIDs to meet specific requirements of the biodiversity information community.
 2. Is a high level document that applies to GUIDs in general. There is, or will be, a separate document for the applicability of each specific GUID technology.
@@ -23,7 +23,7 @@ The [TDWG Globally Unique Identifiers (GUID) applicability statement](guid/tdwg_
 
 ## LSID applicability statement
 
-The [TDWG Life Science Identifiers (LSID) applicability statement](lsid/applicability_statement.doc):
+The [TDWG Life Science Identifiers (LSID) applicability statement](https://github.com/tdwg/guid-as/blob/master/lsid/applicability_statement.doc):
 
 1. Is a specific GUID applicability statement that should be read in conjunction with the general GUID applicability statement.
 2. Provides guidance on how to use Life Science Identifiers (LSID) to meet specific requirements of the biodiversity information community.


### PR DESCRIPTION
The relative links don't work because the actual applicability statements are in the github repo rather than on the website.