### PR TITLE
Revert to {filename} for pages and correct relative paths

### DIFF
--- a/content/pages/about/executive/2018/index.md
+++ b/content/pages/about/executive/2018/index.md
@@ -21,11 +21,11 @@ Treasurer | [William Ulate](mailto:treasurer@tdwg.org) | Missouri Botanical Gard
 
 Functional subcommittee | Name | Affiliation | Term of office
 --- | --- | --- | ---
-[Technical Architecture Group]({static}../committees/tag/index.md) | [Paul Morris](mailto:mole@morris.net) | Museum of Comparative Zoology, MA, USA | 2018-2019
-[Fundraising and Partnerships]({static}../committees/fundraising/index.md) | [Martin Kalfatovic](mailto:martin.kalfatovic@gmail.com) | Smithsonian Institution Libraries and Biodiversity Heritage Library, Washington DC, USA | 2017-2018
-[Infrastructure]({static}../committees/infrastructure/index.md) | [Tim Robertson](mailto:trobertson@gbif.org) | Global Biodiversity Information Facility, Denmark | 2018-2019
-[Outreach and Communications]({static}../committees/outreach/index.md) | [Prabhakar Rajagopal](mailto:prabha.prabhakar@gmail.com) | Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), India | 2017-2018
-[Time and Place]({static}../committees/tardis/index.md) | [Patricia Mergen](mailto:mergen.patricia@gmail.com) | Royal Museum for Central Africa and Botanic Garden Meise, Belgium | 2018-2019
+[Technical Architecture Group]({filename}../../committees/tag/index.md) | [Paul Morris](mailto:mole@morris.net) | Museum of Comparative Zoology, MA, USA | 2018-2019
+[Fundraising and Partnerships]({filename}../../committees/fundraising/index.md) | [Martin Kalfatovic](mailto:martin.kalfatovic@gmail.com) | Smithsonian Institution Libraries and Biodiversity Heritage Library, Washington DC, USA | 2017-2018
+[Infrastructure]({filename}../../committees/infrastructure/index.md) | [Tim Robertson](mailto:trobertson@gbif.org) | Global Biodiversity Information Facility, Denmark | 2018-2019
+[Outreach and Communications]({filename}../../committees/outreach/index.md) | [Prabhakar Rajagopal](mailto:prabha.prabhakar@gmail.com) | Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), India | 2017-2018
+[Time and Place]({filename}../../committees/tardis/index.md) | [Patricia Mergen](mailto:mergen.patricia@gmail.com) | Royal Museum for Central Africa and Botanic Garden Meise, Belgium | 2018-2019
 
 ### Regional representatives
 

--- a/content/pages/about/executive/2019/index.md
+++ b/content/pages/about/executive/2019/index.md
@@ -19,11 +19,11 @@ Treasurer | [William Ulate](mailto:treasurer@tdwg.org) | Missouri Botanical Gard
 
 Functional subcommittee | Name | Affiliation | Term of office
 --- | --- | --- | ---
-[Technical Architecture Group]({static}../committees/tag/index.md) | [Paul Morris](mailto:mole@morris.net) | Museum of Comparative Zoology, MA, USA | 2018-2019
-[Fundraising and Partnerships]({static}../committees/fundraising/index.md) | [Connie Rinaldo](mailto:@) | Ernst Mayr Library of the Museum of Comparative Zoology (MCZ), Harvard University, Cambridge, MA, USA | 2019-2020
-[Infrastructure]({static}../committees/infrastructure/index.md) | [Tim Robertson](mailto:trobertson@gbif.org) | Global Biodiversity Information Facility, Denmark | 2018-2019
-[Outreach and Communications]({static}../committees/outreach/index.md) | [Prabhakar Rajagopal](mailto:prabha.prabhakar@gmail.com) | Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), India | 2019-2020
-[Time and Place]({static}../committees/tardis/index.md) | [Patricia Mergen](mailto:mergen.patricia@gmail.com) | Royal Museum for Central Africa and Botanic Garden Meise, Belgium | 2018-2019
+[Technical Architecture Group]({filename}../../committees/tag/index.md) | [Paul Morris](mailto:mole@morris.net) | Museum of Comparative Zoology, MA, USA | 2018-2019
+[Fundraising and Partnerships]({filename}../../committees/fundraising/index.md) | Connie Rinaldo | Ernst Mayr Library of the Museum of Comparative Zoology (MCZ), Harvard University, Cambridge, MA, USA | 2019-2020
+[Infrastructure]({filename}../../committees/infrastructure/index.md) | [Tim Robertson](mailto:trobertson@gbif.org) | Global Biodiversity Information Facility, Denmark | 2018-2019
+[Outreach and Communications]({filename}../../committees/outreach/index.md) | [Prabhakar Rajagopal](mailto:prabha.prabhakar@gmail.com) | Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), India | 2019-2020
+[Time and Place]({filename}../../committees/tardis/index.md) | [Patricia Mergen](mailto:mergen.patricia@gmail.com) | Royal Museum for Central Africa and Botanic Garden Meise, Belgium | 2018-2019
 
 ### Regional representatives
 

--- a/content/pages/about/executive/index.md
+++ b/content/pages/about/executive/index.md
@@ -10,7 +10,7 @@ page_order: 1
 
 ## Executive responsibilities and elections
 
-TDWG is led by an Executive Committee composed of officers elected by TDWG members. The Executive Committee is responsible for strategic direction, the high-level management and coordination of standards efforts, and the oversight of day-to-day operations. The roles and responsibilities of each officer are set forth in the [Constitution]({static}../constitution/index.md) and further described in a [supplementary document]({static}TDWG_Executive_Committee_RolesAndResponsibilities.pdf).
+TDWG is led by an Executive Committee composed of officers elected by TDWG members. The Executive Committee is responsible for strategic direction, the high-level management and coordination of standards efforts, and the oversight of day-to-day operations. The roles and responsibilities of each officer are set forth in the [Constitution]({filename}../constitution/index.md) and further described in a [supplementary document]({static}TDWG_Executive_Committee_RolesAndResponsibilities.pdf).
 
 The term of office for all roles is normally two calendar years, with terms staggered such that only half of the Executive Committee is replaced or re-elected in a given year. Elections of officers are usually held in the 3rd or 4th Quarter of the year. Nominations are typically opened a month before the annual meeting and closed near the end of the meeting. Ballots are then distributed to members by email and voting is closed in approximately 30 days. (Scheduling the annual conference late in the year requires this typical schedule to be altered so that elections are completed before the end of year.) 
 
@@ -31,11 +31,11 @@ Treasurer | [William Ulate](mailto:treasurer@tdwg.org) | Missouri Botanical Gard
 
 Functional subcommittee | Name | Affiliation | Term of office
 --- | --- | --- | ---
-[Technical Architecture Group]({static}../committees/tag/index.md) | [Paul Morris](mailto:mole@morris.net) | Museum of Comparative Zoology, MA, USA | 2018-2019
-[Fundraising and Partnerships]({static}../committees/fundraising/index.md) | [Martin Kalfatovic](mailto:martin.kalfatovic@gmail.com) | Smithsonian Institution Libraries and Biodiversity Heritage Library, Washington DC, USA | 2017-2018
-[Infrastructure]({static}../committees/infrastructure/index.md) | [Tim Robertson](mailto:trobertson@gbif.org) | Global Biodiversity Information Facility, Denmark | 2018-2019
-[Outreach and Communications]({static}../committees/outreach/index.md) | [Prabhakar Rajagopal](mailto:prabha.prabhakar@gmail.com) | Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), India | 2017-2018
-[Time and Place]({static}../committees/tardis/index.md) | [Patricia Mergen](mailto:mergen.patricia@gmail.com) | Royal Museum for Central Africa and Botanic Garden Meise, Belgium | 2018-2019
+[Technical Architecture Group]({filename}../committees/tag/index.md) | [Paul Morris](mailto:mole@morris.net) | Museum of Comparative Zoology, MA, USA | 2018-2019
+[Fundraising and Partnerships]({filename}../committees/fundraising/index.md) | [Martin Kalfatovic](mailto:martin.kalfatovic@gmail.com) | Smithsonian Institution Libraries and Biodiversity Heritage Library, Washington DC, USA | 2017-2018
+[Infrastructure]({filename}../committees/infrastructure/index.md) | [Tim Robertson](mailto:trobertson@gbif.org) | Global Biodiversity Information Facility, Denmark | 2018-2019
+[Outreach and Communications]({filename}../committees/outreach/index.md) | [Prabhakar Rajagopal](mailto:prabha.prabhakar@gmail.com) | Strand Life Sciences and Ashoka Trust for Research in Ecology and the Environment (ATREE), India | 2017-2018
+[Time and Place]({filename}../committees/tardis/index.md) | [Patricia Mergen](mailto:mergen.patricia@gmail.com) | Royal Museum for Central Africa and Botanic Garden Meise, Belgium | 2018-2019
 
 ### Regional representatives
 


### PR DESCRIPTION
@stanblum and others. How to debug a website build fail:

1. Go to https://builds.gbif.org/job/tdwg-website/
2. Notice that the latest build(s) (including 590) have a red dot, meaning they failed
3. Click the latest build: https://builds.gbif.org/job/tdwg-website/590/
4. Click "Console Output": https://builds.gbif.org/job/tdwg-website/590/console
5. Scan output for `ERROR` or ` CRITICAL`. I notice:

```bash
== Running pelican ==
CRITICAL: FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/jenkins/jobs/tdwg-website/workspace/content/pages/about/executive/committees/tardis/index.md'
Build step 'Execute shell' marked build as failure
```

6. Apparently something is linking to `about/executive/committees/tardis/index.md`, but that page doesn't exist. Indeed, the correct file is at `about/committees/tardis/index.md` (without executive).
7. Where did someone last update content?
8. Go to the repo: https://github.com/tdwg/website
9. Click commits: https://github.com/tdwg/website/commits/master
10. Notice the red x next to the latest commits
11. Aha, in the executive pages, let's check there

So, the actual error was twofold:

1. In Pelican 4, links to static files now use the `{static}` syntax. I updated that on every page that generated a deprecation warning. But on the exec pages I've also updated links to _pages_, but those should remain using the `{filename}` syntax (except if we decide to do it simpler #58).
2. An executive/2019 page was created, and all relative links were copied from the main exec page. That broke them, because the page is one level deeper (so links should have `../../`). Normally, Pelican just warns if a link to a page is broken, but for static files it fails the build. Since the `{static}` syntax was (incorrectly) used, Pelican failed rather than warned.