### PR TITLE
Remove current (2005) status

### DIFF
--- a/content/pages/standards/abcd/index.md
+++ b/content/pages/standards/abcd/index.md
@@ -4,7 +4,7 @@ summary:
 cover_image: https://c1.staticflickr.com/1/839/41611348922_d4030a5197_b.jpg
 cover_image_by: Natural History Museum: Coleoptera Section
 cover_image_ref: https://www.flickr.com/photos/nhm_beetle_id/41611348922/
-tags: technical specification, 2005 standard, 2005
+tags: technical specification, current standard, 2005
 github: https://github.com/tdwg/abcd
 ---
 

--- a/content/pages/standards/delta/index.md
+++ b/content/pages/standards/delta/index.md
@@ -4,7 +4,7 @@ summary:
 cover_image: https://images.unsplash.com/photo-1459664018906-085c36f472af
 cover_image_by: Erol Ahmed
 cover_image_ref: https://unsplash.com/photos/aIYFR0vbADk
-tags: technical specification, 2005 standard, 1986
+tags: technical specification, current standard, 1986
 github: https://github.com/tdwg/delta
 ---
 

--- a/content/pages/standards/index.md
+++ b/content/pages/standards/index.md
@@ -4,7 +4,7 @@ summary: From [Darwin Core]({filename}/pages/standards/dwc/index.md) to [WGSRPD]
 cover_image: https://images.unsplash.com/photo-1518709766631-a6a7f45921c3
 cover_image_by: sutirta budiman
 cover_image_ref: https://unsplash.com/photos/PdiOj8kRy28
-tag_sections: Current standard, Draft standard, 2005 standard, Prior standard
+tag_sections: Current standard, Draft standard, Prior standard
 template: page_tag_sections
 page_order: 1
 ---

--- a/content/pages/standards/sdd/index.md
+++ b/content/pages/standards/sdd/index.md
@@ -4,7 +4,7 @@ summary:
 cover_image: 
 cover_image_by: 
 cover_image_ref: 
-tags: technical specification, 2005 standard, 2005
+tags: technical specification, current standard, 2005
 github: https://github.com/tdwg/sdd
 ---
 

--- a/content/pages/standards/status-and-categories/index.md
+++ b/content/pages/standards/status-and-categories/index.md
@@ -24,8 +24,7 @@ Standards that were ratified prior to 2005 and that are not currently being prom
 
 ### Retired Standard  
 
-Standards that have been ratified by TDWG in the past but that are no longer recommended.  
-
+Standards that have been ratified by TDWG in the past but that are no longer recommended.
 
 ## Categories of TDWG standards
 

--- a/content/pages/standards/status-and-categories/index.md
+++ b/content/pages/standards/status-and-categories/index.md
@@ -14,10 +14,6 @@ page_order:
 
 Standards that TDWG recommends for use.
 
-### Current (2005) Standard  
-
-Standards that TDWG recommends for use and were ratified by membership vote at the TDWG Annual Meeting 2005 in St. Petersburgh. These standards are not in the format of current TDWG standards, nor have they been submitted to both expert and public review, the ratification process adopted at the St Louis annual meeting in 2006.
-
 ### Draft Standard  
 
 Standard under review submitted to the TDWG Standards Track after 2006.

--- a/content/pages/standards/tcs/index.md
+++ b/content/pages/standards/tcs/index.md
@@ -4,7 +4,7 @@ summary:
 cover_image: https://images.unsplash.com/photo-1502912143929-50c8a1ce1f69
 cover_image_by: Fancycrave
 cover_image_ref: https://unsplash.com/photos/4A8ZSlAOUqs
-tags: technical specification, 2005 standard, 2005
+tags: technical specification, current standard, 2005
 github: https://github.com/tdwg/tcs
 ---
 


### PR DESCRIPTION
As suggested by @stanblum, this PR removes the status `Current (2005)` for 4 standards and merges them with `Current`, joining 6 standards already in that status: https://www.tdwg.org/standards/ The other two statuses `draft standards` and `prior standard` remain.

I'd like to get :+1: from @tdwg/tag-team (cc. @baskaufs @tucotuco @chicoreus) before proceeding. If I don't receive any feedback in a week from now, I'll merge this PR.

---

These are the 4 standards with the status `Current (2005)`:

- http://www.tdwg.org/standards/abcd
- http://www.tdwg.org/standards/delta
- http://www.tdwg.org/standards/sdd
- http://www.tdwg.org/standards/tcs

Which has the definition:

> Standards that TDWG recommends for use and were ratified by membership vote at the TDWG Annual Meeting 2005 in St. Petersburgh. These standards are not in the format of current TDWG standards, nor have they been submitted to both expert and public review, the ratification process adopted at the St Louis annual meeting in 2006.

We'd like to remove the status because:

- In contrast with `Current`, `Draft` and `Prior` (which could be called `Deprecated`) this status is rather odd to keep around.
- "Current (2005)" implies _Current_ standards. The fact that they didn't go through a specific review process is not part of the definition of "Current", although we could add to the definition:

> Standards that TDWG recommends for use. **Starting in 2006 standards require expert and public review before they can be ratified and recommended for use.**

- Some of these standards (e.g. DELTA) might look odd to have in a status called "Current" (i.e. recommended for use), but the same applies to e.g. the GUID Applicability statements which is already in that status. Merging the two statuses just simplifies things.
- Each standard has a tag with the year it was adopted/ratified, so you can still differentiate between them if you want.