### PR TITLE
Struck through no sharing

### DIFF
--- a/content/pages/conferences/2020/code-of-conduct/index.md
+++ b/content/pages/conferences/2020/code-of-conduct/index.md
@@ -25,8 +25,8 @@ Accordingly, the conference organizers prohibit intimidating, threatening, or ha
 
 **Authors and Presenters** should conform to the highest standards of scientific attribution and citation in their abstracts and presentations. All authors connected to a presentation and its associated abstract must be aware of and agree with the information presented. Obtaining consent from all authors associated with the presentation is the responsibility of the lead author. The presenter of a submitted abstract must have intention of registering, attending, and participating in the meeting once the submission is accepted into the program. 
 
-Please respect the presenter's "no sharing" ([crossed out Twitter logo](https://blogs.plos.org/paleocomm/files/2015/11/No-tweeting-logo.jpg)) on slides or posters.
+~~Please respect the presenter's "no sharing" (crossed out Twitter logo) on slides or posters.~~
 
 Because TDWG's mission is to reach as broad an audience as possible, abstracts are published, and presentations (audio/video, slides, and posters) may be streamed, recorded, and made publically available. TDWG reserves the right to use photographs and videos taken and testimonials given during this event or in subsequent meeting surveys for informational and promotional purposes.
 
-_Last revised 10 June 2020_
+_Last revised 13 August 2020_


### PR DESCRIPTION
Struck through the sentence on no sharing and updated the last revised date.  It was pointed out that the link to the crossed out Twitter logo was no longer available (404'd) but attempts to find a new image able to be expressly freely used sparked further discussion of whether this entire sentence was moot in a virtual conference with free registration and whose content will be posted. Because the sentence had been part of the Code, it was deemed to use strikethrough rather than remove it so that participants will know what changed. The bad link was removed, however.