### PR TITLE
Commented out link to Google Calendar until we fix

### DIFF
--- a/content/pages/conferences/2020/conference-schedule/index.md
+++ b/content/pages/conferences/2020/conference-schedule/index.md
@@ -96,7 +96,7 @@ function DiaLocal(hileraFechaHora, lineas, formatoDia, formatoMes, localidad) {
 
 The times posted for events below in UTC (and in local time <script type="text/javascript"> document.write( UTCZonaHorariaLocal('2020-10-19T00:00:00Z', 2) ); </script>) are nearly final, but some confirmations are still pending so changes are still possible.
 
-Use this [Google Calendar](https://calendar.google.com/calendar/u/0?cid=Y191N25zMmIxY21kMzUzbnRsdmNjZWlqcmt0OEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) link to add the TDWG2020 Conference Schedule to your calendar in your time zone. 
+<!--- Use this [Google Calendar](https://calendar.google.com/calendar/u/0?cid=Y191N25zMmIxY21kMzUzbnRsdmNjZWlqcmt0OEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) link to add the TDWG2020 Conference Schedule to your calendar in your time zone. --> 
 
 <script type="text/javascript"> 
   // Some configuration variables


### PR DESCRIPTION
Google Calendar needs fixing @qgroom -- can you help? @jmacklin notes: I just checked my Google Calendar and noticed that the CO1:1 is showing the wrong day (Tuesday not Wednesday)...? My talks are in this session! ;-) Spot checking, other sessions seem correct. (please also check Ken-ichi's talk time. Roger Hyam pointed out an issue, but honestly, I'm not sure which time for Ken-ichi is correct).