### PR TITLE
removed extraneous close tag before Pensoft logo

### DIFF
--- a/content/pages/conferences/2021/index.md
+++ b/content/pages/conferences/2021/index.md
@@ -51,7 +51,6 @@ TDWG gratefully acknowledges the financial or in-kind support of TDWG 2021 by th
 </td>
   </tr>
 <tr>
-    </td>
   <td style="background-color: #FFFFFF; vertical-align: middle;">
     <a href="https://pensoft.net">
     <img src="https://static.tdwg.org/sponsors/pensoft-logo.png" alt="Pensoft Publishers logo" width="" height="" />


### PR DESCRIPTION
Trying to get Pensoft logo to size properly within table cell.