### PR TITLE
Initial posting of terms of use

### DIFF
--- a/content/pages/about/terms-of-use/index.md
+++ b/content/pages/about/terms-of-use/index.md
@@ -1,0 +1,50 @@
+---
+title: Terms of Use
+summary: 
+cover_image: https://images.unsplash.com/photo-1544187572-55a7bd7390a9?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1050&q=80
+cover_image_by: Kallanai Dam, Thanjavur, India
+cover_image_ref: https://unsplash.com/photos/pZmcfWEdjrw
+tags: policy
+toc_headers: ^h[2-3]
+page_order: 20
+---
+
+# Terms of Use
+
+This document describes the Terms of Use of the Biodiversity Information Standards (TDWG) platforms, including, but not limited to its website, GitHub, email, listservs, YouTube, Facebook, Twitter, and content or media published in its Pensoft journal, [_Biodiversity Information Science and Standards_](https://biss.pensoft.net/) (BISS). All Users agree to these Terms of Use.
+
+TDWG reserves the right to update the Terms of Use. Users will be notified via posting on the website. If using TDWG after such notice, the User will be deemed to have accepted the proposed modifications. If the User disagrees with the modifications, they should stop using the TDWG platforms. 
+
+## User Responsibility
+1.  Users are solely responsible for their content posted via TDWG's platforms (including, but not limited to data, text, files, information, usernames, images, graphics, photos, profiles, audio and video clips, sounds, applications, links and other content). Proper attribution of content used or cited is expected.
+2. Users will be solely liable for any damage resulting from any infringement of copyrights, proprietary rights or any other harm resulting from their submissions.
+
+## Privacy Statement
+
+The ‘legitimate interest’ of TDWG is to engage with the User and enable them to participate in TDWG's activities corresponding to [Article 6(1)(f) of the GDPR](https://gdpr-info.eu/art-6-gdpr/) (General Data Protection Regulation).  Accordingly, 
+
+1.  TDWG collects personal information from Users (e.g., name, postal and email addresses, affiliation) only for the purpose of its services.
+2.  Personal data purposefully collected by TDWG will be used exclusively for the stated purposes of the platform on which it appears and will not be made available to third parties without prior permission of users.
+3.  If TDWG starts using personal data for purposes other than those specified in the Terms of Use, TDWG will immediately inform the person and request their consent.
+    1.  If consent to the processing of personal data is not given, TDWG shall cease the processing of this personal data, unless there is another legal basis for the processing.   
+4.  Users may receive emails from the publisher, Pensoft, host of TDWG's journal [_Biodiversity Information Science and Standards_](https://biss.pensoft.net) (BISS) about activities they have given their consent for. See [Pensoft Terms & Conditions](https://pensoft.net/terms).
+
+## Ownership
+
+TDWG reserves the right to modify or discontinue, temporarily or permanently, the platforms and services it provides. 
+
+The User retains full ownership of the content uploaded on TDWG platforms, including, but not limited to its website, GitHub, YouTube, Facebook, Twitter, and content or media published with BISS. However, by setting pages to be viewed publicly, the User agrees to allow others to view and download the relevant content. In addition, publicly available data might be used by TDWG or third parties for data mining purposes.
+
+TDWG reserves the right, in its sole discretion, to refuse or remove any content that is available via its platforms.
+
+## License for Use
+
+TDWG is a supporter of open science. Content on our website is available under the  Creative Commons Attribution 4.0 license ([CC-BY](https://creativecommons.org/licenses/by/4.0/)) unless otherwise stated.
+
+## Disclaimer of Warranty and Limitation of Liability
+
+Neither TDWG, its affiliates nor any of their respective employees, agents, third party content providers or licensors warrant that media associated with TDWG will be uninterrupted or error free; nor do they give any warranty as to the results that may be obtained from the use of the platform or as to the accuracy or reliability of any information, service or merchandise provided through TDWG.
+
+In no event will TDWG, or any person or entity involved in creating, producing or distributing the content on TDWG platform(s) or the contents included therein, be liable in contract, in tort (including for its own negligence) or under any other legal theory (including strict liability) for any damages, including, but without limitation to, direct, indirect, incidental, special, punitive, consequential or similar damages, including, but without limitation to, lost profits or revenues, loss of use or similar economic loss, arising from the use of or inability to use the platform. The User hereby acknowledges that the provisions of this section will apply to all use of the content on any TDWG-related platforms. Applicable law may not allow the limitation or exclusion of liability or incidental or consequential damages, so the above limitation or exclusion may not apply to the User. In no event will TDWG's total liability to the User for all damages, losses or causes of action, whether in contract, tort (including own negligence) or under any other legal theory (including strict liability), exceed the amount paid by the User, if any, for accessing the TDWG-related platforms and their subordinate services.
+
+_Last revised 16 June 2021_


### PR DESCRIPTION
From https://docs.google.com/document/d/1xaHIZ3_jXazYLIZkPJGlQJJKSR4aq_BAMlOQVBNfy94/edit#
Note that the privacy statement is here, but the current tile for this is empty, even though it is linked in the footer.
Please also check that the image used displays correctly. Thanks!