### PR TITLE
fixed convener email link

### DIFF
--- a/content/pages/community/tnc/index.md
+++ b/content/pages/community/tnc/index.md
@@ -10,8 +10,8 @@ github: https://github.com/tdwg/tnc
 
 ## Convener
 
-[Niels Klazenga](Niels.Klazenga@rbg.vic.gov.au)  
-Royal botanic Gardens Victoria
+[Niels Klazenga](mailto:Niels.Klazenga@rbg.vic.gov.au)  
+Royal Botanic Gardens Victoria
 
 ## Summary
 


### PR DESCRIPTION
capitalized 'botanic'