### PR TITLE
Update standards landing pages to conform to Standards Documentation Specification

### DIFF
--- a/content/pages/standards/abcd/index.md
+++ b/content/pages/standards/abcd/index.md
@@ -2,7 +2,7 @@
 title: Access to Biological Collection Data (ABCD) Schema
 summary: The Access to Biological Collections Data (ABCD) Schema is an evolving comprehensive standard for the access to and exchange of data about specimens and observations (a.k.a. primary biodiversity data).
 cover_image: https://c1.staticflickr.com/1/839/41611348922_d4030a5197_b.jpg
-cover_image_by: “Natural History Museum: Coleoptera Section”
+cover_image_by: "Natural History Museum: Coleoptera Section"
 cover_image_ref: https://www.flickr.com/photos/nhm_beetle_id/41611348922/
 tags: technical specification, 2005 standard, 2005
 github: https://github.com/tdwg/abcd

--- a/content/pages/standards/abcd/index.md
+++ b/content/pages/standards/abcd/index.md
@@ -1,8 +1,8 @@
 ---
-title: Access to Biological Collection Data (ABCD)
+title: Access to Biological Collection Data (ABCD) Schema
 summary: The Access to Biological Collections Data (ABCD) Schema is an evolving comprehensive standard for the access to and exchange of data about specimens and observations (a.k.a. primary biodiversity data).
 cover_image: https://c1.staticflickr.com/1/839/41611348922_d4030a5197_b.jpg
-cover_image_by: "Natural History Museum: Coleoptera Section"
+cover_image_by: “Natural History Museum: Coleoptera Section”
 cover_image_ref: https://www.flickr.com/photos/nhm_beetle_id/41611348922/
 tags: technical specification, 2005 standard, 2005
 github: https://github.com/tdwg/abcd
@@ -15,23 +15,57 @@ website_title: ABCD version 2.06
 Title
 : Access to Biological Collection Data (ABCD) Schema
 
-Date created
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/115>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2005-09-16
 
 Status
-: Current (2005) standard
+: [Current (2005) standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/115>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
-: The Access to Biological Collections Data (ABCD) Schema is an evolving comprehensive standard for the access to and exchange of data about specimens and observations (a.k.a. primary biodiversity data). The ABCD Schema attempts to be comprehensive and highly structured, supporting data from a wide variety of databases. It is compatible with several existing data standards. Parallel structures exist so that either (or both) atomised data and free-text can be accommodated. Versions 1.2 and 2.06 are currently in use with the [GBIF](http://www.gbif.org/) (Global Biodiversity Information Facility) and [BioCASe](http://www.biocase.org/) (Biological Collection Access Service for Europe) networks. Apart from the GBIF and BioCASe networks, the potential for the application of ABCD extends to internal networks, or in-house legacy data access (e.g. datasets from external sources that shall not be converted and integrated into an institution's own data, but be kept separately, though easily accessible). By defining relations between terms, ABCD is a step towards an ontology for biological collections.
-
-Creator
-: Access to Biological Collections Data task group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+: The Access to Biological Collections Data (ABCD) Schema is an evolving comprehensive standard for the access to and exchange of data about specimens and observations (a.k.a. primary biodiversity data). The ABCD Schema attempts to be comprehensive and highly structured, supporting data from a wide variety of databases. It is compatible with several existing data standards. Parallel structures exist so that either (or both) atomised data and free-text can be accommodated. Versions 1.2 and 2.06 are currently in use with the GBIF (Global Biodiversity Information Facility, http://www.gbif.org/ ) and  BioCASe (Biological Collection Access Service for Europe, http://www.biocase.org/ ) networks. Apart from the GBIF and BioCASe networks, the potential for the application of ABCD extends to internal networks, or in-house legacy data access (e.g. datasets from external sources that shall not be converted and integrated into an institution's own data, but be kept separately, though easily accessible). By defining relations between terms, ABCD is a step towards an ontology for biological collections.
 
 Bibliographic citation
-: > Access to Biological Collections Data task group (2007) Access to Biological Collection Data (ABCD), Version 2.06. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/115>
+: > Access to Biological Collections Data Task Group. 2005. Access to Biological Collection Data (ABCD). Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/115
+
+## Parts of the standard
+
+This standard is comprised of 2 documents. 
+
+Documents:
+
+**Title:** Access to Biological Collection Data (ABCD) Primer \
+**Permanent IRI:** [http://rs.tdwg.org/abcd/doc/primer/](https://github.com/tdwg/wiki-archive/blob/master/twiki/data/ABCD/AbcdPrimer.txt) \
+**Created:** 2006-07-27 \
+**Last modified:** 2006-07-27 \
+**Contributors:** \
+Neil Thomson (author) - Natural History Museum, London \
+Markus Döring (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
+Javier de la Torre (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+Walter G. Berendsohn (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+Wouter Addink (author) - Expertise Centre for Taxonomic Identification, Amsterdam  \
+William Ulate  (author) - INBioparque, Santo Domingo de Heredia  \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This primer is intended to provide an easily readable background to ABCD and should take anyone with no knowledge of the standard to the very point where they would be able to understand the principles and the more detailed technical specification. Examples are given which are complemented by references to the normative texts. \
+**Citation:** TDWG Access to Biological Collections Data (ABCD) Task Group 2006. Access to Biological Collections Data (ABCD) Primer. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/abcd/doc/primer/
+
+**Title:** Access to Biological Collection Data (ABCD) XML Schema \
+**Permanent IRI:** [http://rs.tdwg.org/abcd/doc/xmlschema/](http://rs.tdwg.org/abcd/2.06/ABCD_2.06.xsd) \
+**Created:** 2007-06-13 \
+**Last modified:** 2007-06-13 \
+**Contributors:** \
+Walter G. Berendsohn (lead author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** XML schema document for the Access to Biological Collection Data standard. \
+**Note:** See also https://raw.githack.com/tdwg/abcd/master/2.06/rddl-2007-10-18.html \
+**Citation:** TDWG Access to Biological Collections Data (ABCD) Task Group 2007. Access to Biological Collections Data (ABCD) XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/abcd/doc/xmlschema/
+

--- a/content/pages/standards/ac/index.md
+++ b/content/pages/standards/ac/index.md
@@ -1,5 +1,5 @@
 ---
-title: Audubon Core
+title: Audubon Core Multimedia Resources Metadata Schema
 summary: The Audubon Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
 cover_image: https://images.unsplash.com/photo-1430990480609-2bf7c02a6b1a
 cover_image_by: Mikhail Vasilyev
@@ -15,35 +15,26 @@ website_title: Audubon Core website
 Title
 : Audubon Core Multimedia Resources Metadata Schema
 
-Date ratified
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/638>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2013-10-28
 
 Status
-: Current standard
+: [Current standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/638>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
 : The Audubon Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
 
-Creator
-: GBIF/TDWG Multimedia Resources Task Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
-
 Bibliographic citation
-: > GBIF/TDWG Multimedia Resources Task Group (2013) Audubon Core Multimedia Resources Metadata Schema (S. Baskauf, review manager). Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/638>
-
-## Parts of the standard
-
-The Audubon Core standard is comprised of one vocabulary, the Audubon Core basic vocabulary (http://rs.tdwg.org/ac/), and four documents:
-
-* [Audubon Core Introduction](https://tdwg.github.io/ac/introduction) (http://rs.tdwg.org/ac/doc/introduction/) - a brief introduction to the standard
-* [Audubon Core Structure](https://tdwg.github.io/ac/structure) (http://rs.tdwg.org/ac/doc/structure/) - the normative description of the structure of Audubon Core
-* [Audubon Core Term List](https://tdwg.github.io/ac/termlist) (http://rs.tdwg.org/ac/doc/termlist/) - a complete list of terms included in Audubon Core, with their normative definitions
-* [Audubon Core Guide](https://tdwg.github.io/ac/guide) (http://rs.tdwg.org/ac/doc/guide/) - a more detailed guide to the aims and uses of the vocabulary
+: > GBIF/TDWG Multimedia Resources Task Group. 2013. Audubon Core Multimedia Resources Metadata Schema. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/638
 
 ## Maintenance group
 
@@ -52,4 +43,138 @@ Audubon Core is maintained by a specialized Interest Group whose [charter](https
 The activities of the AC Maintenance Group are documented at the group's Github repository, <https://github.com/tdwg/ac>, where a current list of core members and their contact information can be found.  Community participation is welcome.  If you would like to participate in this group, contact the convener or one of the core members.  
 
 To participate in the communications of the group, "watch" the group's [Issues tracker](https://github.com/tdwg/ac/issues).  This issues tracker is the mechanism for suggesting specific changes to the standard as well as to raise issues for discussion by the group.
- as well as to raise issues for discussion by the group.
+
+## Parts of the standard
+
+This standard is comprised of 4 vocabularies and 7 documents. 
+
+Vocabularies:
+
+Audubon Core main vocabulary (<http://rs.tdwg.org/ac/>)
+variant controlled vocabulary (<http://rs.tdwg.org/acvariant/>)
+format controlled vocabulary (<http://rs.tdwg.org/format/>)
+subtype controlled vocabulary (<http://rs.tdwg.org/acsubtype/>)
+
+Documents:
+
+**Title:** Audubon Core Term List \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/termlist/](https://tdwg.github.io/ac/termlist/) \
+**Created:** 2013-10-23 \
+**Last modified:** 2021-02-01 \
+**Contributors:** \
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
+Vijay Barve (author) \
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
+José Cuadra (author) \
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
+Patrick Leary (author) \
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
+Annette Olson (author) - American Association for the Advancement of Science \
+Greg Riccardi (author) - Florida State University, Tallahassee, USA \
+Ivan Teage (author) \
+Steve Baskauf (author) - Audubon Core Maintenance Group \
+Dan Stowell (author) - Queen Mary University of London \
+Edward Baker (author) - Natural History Museum, London \
+Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. It aims to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains a list of attributes of each Audubon Core term, including a documentation name, a specified URI, a recommended English label for user interfaces, a definition, and some ancillary notes. The version shown here was adopted by Biodiversity Information Standards / TDWG at the general meeting in October 2013 and updated in 2021. This document contains normative content that may not be changed without due process. \
+**Citation:** Audubon Core Maintenance Group. 2021. Audubon Core Term List. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/termlist/2021-02-01
+
+**Title:** Audubon Core Structure \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/structure/](https://tdwg.github.io/ac/structure/) \
+**Created:** 2013-10-23 \
+**Last modified:** 2020-01-27 \
+**Contributors:** \
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
+Vijay Barve (author) \
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
+José Cuadra (author) \
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
+Patrick Leary (author) \
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
+Annette Olson (author) - American Association for the Advancement of Science \
+Greg Riccardi (author) - Florida State University, Tallahassee, USA \
+Ivan Teage (author) \
+Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains material introductory to the Audubon Core Term List. \
+**Citation:** Multimedia Resources Task Group. 2013. Audubon Core Structure. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/structure/
+
+**Title:** Audubon Core Introduction \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/introduction/](https://tdwg.github.io/ac/introduction/) \
+**Created:** 2013-10-23 \
+**Last modified:** 2013-10-23 \
+**Contributors:** \
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
+Vijay Barve (author) \
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
+José Cuadra (author) \
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
+Patrick Leary (author) \
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
+Annette Olson (author) - American Association for the Advancement of Science \
+Greg Riccardi (author) - Florida State University, Tallahassee, USA \
+Ivan Teage (author) \
+Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.  \
+**Citation:** Multimedia Resources Task Group. 2013. Audubon Core Introduction. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/introduction/
+
+**Title:** Audubon Core Guide \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/guide/](https://tdwg.github.io/ac/guide/) \
+**Created:** 2013-10-15 \
+**Last modified:** 2013-10-15 \
+**Contributors:** \
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
+Annette Olson (author) - American Association for the Advancement of Science \
+Greg Riccardi (author) - Florida State University, Tallahassee, USA \
+Éamonn Ó Tuama (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. This non-normative document provides some background to the aims and uses of the standard. \
+**Citation:** Multimedia Resources Task Group. 2013. Audubon Core Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/guide/
+
+**Title:** Controlled Vocabulary for Dublin Core format: List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/format/](https://tdwg.github.io/ac/format/) \
+**Created:** 2020-10-13 \
+**Last modified:** 2020-10-13 \
+**Contributors:** \
+Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries \
+Matthew Blissett (contributor) - Global Biodiversity Information Facility \
+Douglas Boyer (contributor) - Duke University \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** Audubon Core borrows the Dublin Core terms dc:format and dcterms:format to provide information about the physical or electronic format of a media item. This controlled vocabulary provides values for those two terms. \
+**Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Dublin Core format: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/format/2020-10-13
+
+**Title:** Controlled Vocabulary for Audubon Core subtype: List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/subtype/](https://tdwg.github.io/ac/subtype/) \
+**Created:** 2020-10-13 \
+**Last modified:** 2020-10-13 \
+**Contributors:** \
+Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** Audubon Core uses the terms ac:subtype and ac:subtypeLiteral to refine the type of a media item to a level more specific than the Dublin Core Type Vocabulary, http://purl.org/dc/dcmitype/. This controlled vocabulary provides values for ac:subtype and ac:subtypeLiteral. \
+**Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core subtype: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/subtype/2020-10-13
+
+**Title:** Controlled Vocabulary for Audubon Core variant: List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/variant/](https://tdwg.github.io/ac/variant/) \
+**Created:** 2020-10-13 \
+**Last modified:** 2020-10-13 \
+**Contributors:** \
+Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries \
+Dan Stowell (contributor) - Queen Mary University of London \
+Edward Baker (contributor) - Natural History Museum, London \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** Audubon Core uses the terms ac:variant and ac:variantLiteral to provide information about the size, extent, and availability of the Service Access Point of a media item. This controlled vocabulary provides values for those terms. \
+**Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core variant: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/variant/2020-10-13
+

--- a/content/pages/standards/bph-supplementum/index.md
+++ b/content/pages/standards/bph-supplementum/index.md
@@ -1,5 +1,5 @@
 ---
-title: Botanico-periodicum-huntianum/supplementum
+title: Botanico-Periodicum-Huntianum/Supplementum
 tags: prior standard, 1991
 github: https://github.com/tdwg/prior-standards/tree/master/botanico-periodicum-huntianum-supplementum
 ---
@@ -7,7 +7,7 @@ github: https://github.com/tdwg/prior-standards/tree/master/botanico-periodicum-
 ## Header section
 
 Title
-: Botanico-periodicum-huntianum/supplementum
+: Botanico-Periodicum-Huntianum/Supplementum
 
 Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/114>

--- a/content/pages/standards/bph-supplementum/index.md
+++ b/content/pages/standards/bph-supplementum/index.md
@@ -1,36 +1,47 @@
 ---
-title: Botanico-Periodicum-Huntianum/Supplementum
-summary: 
-cover_image: 
-cover_image_by: 
-cover_image_ref: 
+title: Botanico-periodicum-huntianum/supplementum
 tags: prior standard, 1991
 github: https://github.com/tdwg/prior-standards/tree/master/botanico-periodicum-huntianum-supplementum
-status: hidden
 ---
 
 ## Header section
 
 Title
-: Botanico-Periodicum-Huntianum/Supplementum
+: Botanico-periodicum-huntianum/supplementum
 
-Date created
-: 1991-10-01
-
-Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/114>
 
-Abstract
-: 
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: 
+Ratified
+: 1991
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Abstract
+: An index of botanical publications and a supplement to Botanico-periodicum-huntianum.
 
 Bibliographic citation
-: 
+: > Bridson, G. D. R. and E. R. Smith. 1991. Botanico-Periodicum-Huntianum/Supplementum Standard. IUBS Commission for Plant Taxonomic Databases (TDWG) http://www.tdwg.org/standards/114
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum \
+**Permanent IRI:** [http://rs.tdwg.org/bphsup/doc/book/](http://huntbotanical.org/publications/show.php?=92) \
+**Created:** 1991 \
+**Last modified:** 1991 \
+**Contributors:** \
+Gavin D. R. Bridson (author) \
+Elizabeth R. Smith (author) \
+**Publisher:** Hunt Institute for Botanical Documentation \
+**Abstract:** A supplement to and partial revision of B-P-H (1968), B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum (1991) contains over 25,000 title entries arranged alphabetically by title and is designed as a key to entries in both volumes. It features citation abbreviations for all titles, improved cross-referencing and an expanded thesaurus of title words and their abbreviation equivalents. The supplement includes periodicals dealing with biotechnology, molecular biology, environmental studies and conservation.  \
+**Note:** Available only in print and is out of print. See http://huntbotanical.org/publications/show.php?=92. Contained additional entries and was a key to entries in it and in the first edition of B-P-H. \
+**Citation:** Bridson, G. D. R. and E. R. Smith. 1991. B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum. Hunt Institute for Botanical Documentation, Carnegie Mellon University (Pittsburgh). ISBN: 0913196541. http://rs.tdwg.org/bphsup/doc/book/
+

--- a/content/pages/standards/bph/index.md
+++ b/content/pages/standards/bph/index.md
@@ -1,5 +1,5 @@
 ---
-title: Botanico-periodicum-huntianum
+title: Botanico-Periodicum-Huntianum
 tags: prior standard, 1970
 github: https://github.com/tdwg/prior-standards/tree/master/botanico-periodicum-huntianum
 ---
@@ -7,7 +7,7 @@ github: https://github.com/tdwg/prior-standards/tree/master/botanico-periodicum-
 ## Header section
 
 Title
-: Botanico-periodicum-huntianum
+: Botanico-Periodicum-Huntianum
 
 Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/112>
@@ -25,7 +25,7 @@ Abstract
 : A list of periodicals with botanical content, including abbreviations for the titles of books.
 
 Bibliographic citation
-: > Bridson, G. D. R. 2004. Botanico-periodicum-huntianum Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/112
+: > Bridson, G. D. R. 2004. Botanico-Periodicum-Huntianum Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/112
 
 ## Parts of the standard
 

--- a/content/pages/standards/bph/index.md
+++ b/content/pages/standards/bph/index.md
@@ -1,36 +1,46 @@
 ---
-title: Botanico-Periodicum-Huntianum
-summary: 
-cover_image: 
-cover_image_by: 
-cover_image_ref: 
+title: Botanico-periodicum-huntianum
 tags: prior standard, 1970
 github: https://github.com/tdwg/prior-standards/tree/master/botanico-periodicum-huntianum
-status: hidden
 ---
 
 ## Header section
 
 Title
-: Botanico-Periodicum-Huntianum
+: Botanico-periodicum-huntianum
 
-Date created
-: 1970-10-01
-
-Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/112>
 
-Abstract
-: 
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: 
+Ratified
+: 1970
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Abstract
+: A list of periodicals with botanical content, including abbreviations for the titles of books.
 
 Bibliographic citation
-: 
+: > Bridson, G. D. R. 2004. Botanico-periodicum-huntianum Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/112
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** B-P-H-2: Periodicals with Botanical content (edition 2) \
+**Permanent IRI:** [http://rs.tdwg.org/bph/doc/book/](http://huntbotanical.org/publications/show.php?=92) \
+**Created:** 1968 \
+**Last modified:** 2004 \
+**Contributors:** \
+Gavin D. R. Bridson (author) - Hunt Institute \
+**Publisher:** Hunt Institute for Botanical Documentation \
+**Abstract:** This edition includes the abbreviations for titles of books. \
+**Note:** The second edition includes material in both the first edition of B-H-P and the 1991 B-P-H/S supplement.  The print version is out of print.  See http://huntbotanical.org/publications/show.php?=92. The online database is at http://huntbotanical.org/databases/show.php?1 \
+**Citation:** Bridson, G. D. R. 2004. B-P-H-2: Periodicals with Botanical content (edition 2). Hunt Institute for Botanical Documentation, Carnegie Mellon University (Pittsburgh). ISBN: 0913196789. http://rs.tdwg.org/bph/doc/book/
+

--- a/content/pages/standards/delta/index.md
+++ b/content/pages/standards/delta/index.md
@@ -13,25 +13,44 @@ website_title: DELTA website
 ## Header section
 
 Title
-: DELTA format (DEscription Language for TAxonomy)
+: Description Language for Taxonomy (DELTA)
 
-Date created
-: 1986-10-01
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/107>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
+: 1986
 
 Status
-: Current (2005) standard
+: [Current (2005) standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/107>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
 : When taxonomic descriptions are prepared for input to computer programs, the form of the coding is usually dictated by the requirements of a particular program or set of programs. This restricts the type of data that can be represented, and the number of other programs that can use the data. Even when working with a particular program, it is frequently necessary to set up different versions of the same basic data, for example, when using restricted sets of taxa or characters to make special-purpose keys. The potential advantages of automation, especially in connexion with large groups, cannot be realized if the data have to be restructured by hand for every operation. The DELTA (DEscription Language for TAxonomy) system was developed to overcome these problems. It was designed primarily for easy use by people rather than for convenience in computer programming, and is versatile enough to replace the written description as the primary means of recording data. Consequently, it can be used as a shorthand method of recording data, even if computer processing of the data is not envisaged.
 
-Creator
-: 
-
 Bibliographic citation
-: > Dallwitz MJ (2006) Description Language for Taxonomy (DELTA), Version 2006-11-24. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/107>
+: > Dallwitz, M. J. 2006. Description Language for Taxonomy (DELTA) Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/107
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Definition of the Delta Format \
+**Permanent IRI:** [http://rs.tdwg.org/delta/doc/definition/](https://github.com/tdwg/delta/blob/master/107-516-1-ED.pdf) \
+**Created:** 2005-09-13 \
+**Last modified:** 2005-09-13 \
+**Contributors:** \
+Michael J. Dallwitz (author) \
+Toni Anne Paine (author) \
+**Publisher:** Commonwealth Scientific and Industrial Research Organisation (CSIRO) \
+**Abstract:** This document is primarily for the benefit of programmers, and contains more detail than would usually be required by users of the DELTA format. It provides an introduction to the format, and details necessary to encode data in the format. \
+**Note:** See http://delta-intkey.com/www/overview.htm for an overview and http://delta-intkey.com/www/use.htm for conditions of use. \
+**Citation:** Dallwitz, M. J. and T. A. Paine. 1999 onwards. Definition of the Delta Format. Version: 2005-09-13. http://delta-intkey.com/
+

--- a/content/pages/standards/dwc/index.md
+++ b/content/pages/standards/dwc/index.md
@@ -15,39 +15,26 @@ website_title: Darwin Core website
 Title
 : Darwin Core
 
-Date ratified
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/450>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2009-10-09
 
 Status
-: Current standard
+: [Current standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/450>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
 : Darwin Core is a standard maintained by the Darwin Core maintenance group. It includes a glossary of terms (in other contexts these might be called properties, elements, fields, columns, attributes, or concepts) intended to facilitate the sharing of information about biological diversity by providing identifiers, labels, and definitions. Darwin Core is primarily based on taxa, their occurrence in nature as documented by observations, specimens, samples, and related information.
 
-Creator
-: Darwin Core Task Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
-
 Bibliographic citation
-: > Darwin Core Task Group (2009) Darwin Core (Kampmeier G, review manager). Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/450>
-
-## Parts of the standard
-
-The Darwin Core standard is comprised of one vocabulary, the Darwin Core vocabulary (<http://rs.tdwg.org/dwc/>), and six documents:
-
-- [List of Darwin Core terms](http://rs.tdwg.org/dwc/doc/list/) - a complete list of all terms in namespaces currently used in the vocabulary
-- [Simple Darwin Core Guide](http://rs.tdwg.org/dwc/terms/simple/) - a guide for sharing information using the simplest methods
-- [Darwin Core Text Guide](http://rs.tdwg.org/dwc/terms/guides/text/) - a guide for sharing information using text files
-- [Darwin Core XML Guide](http://rs.tdwg.org/dwc/terms/guides/xml/) - a guide for constructing application schemas using XML
-- [Darwin Core RDF Guide](http://rs.tdwg.org/dwc/terms/guides/rdf/) - a guide for encoding biodiversity data using the Resource Description Framework (RDF)
-- [Darwin Core Namespace Policy](http://rs.tdwg.org/dwc/terms/namespace/) - an explanation of how URIs for Darwin Core terms should be constructed
-
-An additional document, the [Quick Reference Guide](https://dwc.tdwg.org/terms/) is maintained outside the standard and summarizes the currently recommended terms.
+: > Darwin Core Task Group. 2009. Darwin Core. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/450
 
 ## Maintenance group
 
@@ -85,8 +72,213 @@ What is not in scope?
 
 ## Resources
 
-- Resource directory: <http://rs.tdwg.org/dwc/>
+- Quick Reference Guide <https://dwc.tdwg.org/terms/>
 - Maintenance group: <https://www.tdwg.org/community/dwc/>
 - Primary collaboration platform: <https://github.com/tdwg/dwc>
 - Darwin Core Questions & Answers: <https://github.com/tdwg/dwc-qa>
 - Darwin Core landing page (this page): <https://www.tdwg.org/standards/dwc/>
+
+## Parts of the standard
+
+This standard is comprised of 5 vocabularies and 11 documents. 
+
+Vocabularies:
+
+Darwin Core main vocabulary (<http://rs.tdwg.org/dwc/>)
+establishmentMeans controlled vocabulary (<http://rs.tdwg.org/dwcem/>)
+degreeOfEstablishment controlled vocabulary (<http://rs.tdwg.org/dwcdoe/>)
+pathway controlled vocabulary (<http://rs.tdwg.org/dwcpw/>)
+Darwin Core Chronometric Age Extension vocabulary (<http://rs.tdwg.org/chrono/>)
+
+Documents:
+
+**Title:** Darwin Core RDF Guide \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/rdf/](https://dwc.tdwg.org/rdf/) \
+**Created:** 2015-06-02 \
+**Last modified:** 2015-06-02 \
+**Contributors:** \
+Steve Baskauf (lead author) - TDWG RDF/OWL Task Group \
+John Wieczorek (author) - TDWG Darwin Core Task Group \
+John Deck  (author) - Genomic Biodiversity Working Group \
+Campbell Webb  (author) - TDWG RDF/OWL Task Group \
+Paul J. Morris  (author) - Harvard University Herbaria/Museum of Comparative Zoölogy \
+Mark Schildhauer  (author) - National Center for Ecological Analysis and Synthesis \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This guide is intended to facilitate the use of Darwin Core terms in the Resource Description Framework (RDF). It explains basic features of RDF and provides details of how to expose data in the form of RDF using Darwin Core terms and terms from other key vocabularies. It defines terms in the namespace http://rs.tdwg.org/dwc/iri/ which are intended for use excusively with non-literal objects.  \
+**Citation:** Darwin Core and RDF/OWL Task Groups. 2015. Darwin Core RDF Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/guides/rdf/
+
+**Title:** Darwin Core Text Guide \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/text/](https://dwc.tdwg.org/text/) \
+**Created:** 2014-11-08 \
+**Last modified:** 2014-11-08 \
+**Contributors:** \
+Tim Robertson (lead author) - Global Biodiversity Information Facility \
+Markus Döring (author) - Global Biodiversity Information Facility \
+John Wieczorek (author) - TDWG Darwin Core Task Group \
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
+Dave Vieglais (author) - KU Natural History Museum \
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document provides guidelines for implementing Darwin Core in Text files. \
+**Citation:** Darwin Core Task Group. 2014. Darwin Core Text Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/guides/text/
+
+**Title:** Darwin Core XML Guide \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/xml/](https://dwc.tdwg.org/xml/) \
+**Created:** 2014-11-08 \
+**Last modified:** 2014-11-08 \
+**Contributors:** \
+John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley \
+Markus Döring (author) - Global Biodiversity Information Facility \
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
+Tim Robertson (author) - Global Biodiversity Information Facility \
+Dave Vieglais (author) - KU Natural History Museum \
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document provides guidelines for the implementation of Darwin Core in XML. \
+**Citation:** Darwin Core Task Group. 2014. Darwin Core XML Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/guides/xml/
+
+**Title:** Simple Darwin Core \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/simple/](https://dwc.tdwg.org/simple/) \
+**Created:** 2014-11-08 \
+**Last modified:** 2014-11-08 \
+**Contributors:** \
+John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley \
+Markus Döring (author) - Global Biodiversity Information Facility \
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
+Tim Robertson (author) - Global Biodiversity Information Facility \
+Dave Vieglais (author) - KU Natural History Museum \
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document is a reference for the Simple Darwin Core standard, a mechanism used to share biodiversity information using the simplest methods and structure.   \
+**Citation:** Darwin Core Task Group. 2014. Simple Darwin Core. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/simple/
+
+**Title:** Darwin Core Namespace Policy \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/namespace/](https://dwc.tdwg.org/namespace/) \
+**Created:** 2014-11-08 \
+**Last modified:** 2014-11-08 \
+**Contributors:** \
+John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley \
+Markus Döring (author) - Global Biodiversity Information Facility \
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
+Tim Robertson (author) - Global Biodiversity Information Facility \
+Dave Vieglais (author) - KU Natural History Museum \
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** All terms in the Darwin Core must be assigned a unique Uniform Resource Identifier (URI). For convenience, the term URIs that are assigned and managed by the Darwin Core Task Group are grouped into collections known as Darwin Core namespaces. This document describes how term URIs are allocated by the Darwin Core Task Group and the policies associated with Darwin Core namespaces.  \
+**Citation:** Darwin Core Task Group. 2014. Darwin Core Namespace Policy. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/namespace/
+
+**Title:** Darwin Core List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/list/](https://dwc.tdwg.org/list/) \
+**Created:** 2020-08-12 \
+**Last modified:** 2021-07-15 \
+**Contributors:** \
+John Wieczorek (contributor) - VertNet \
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Steve Baskauf (contributor) - Vanderbilt University Libraries \
+Tim Robertson (contributor) - Global Biodiversity Information Facility \
+Markus Döring (contributor) - Global Biodiversity Information Facility \
+Quentin Groom (contributor) - Botanic Garden Meise \
+Stijn Van Hoey (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+David Bloom (contributor) - VertNet \
+Paula Zermoglio (contributor) - VertNet \
+Robert Guralnick (contributor) - University of Florida \
+John Deck (contributor) - Genomic Biodiversity Working Group \
+Gail Kampmeier (review manager) - Illinois Natural History Survey \
+Dave Vieglais (contributor) - KU Natural History Museum \
+Renato De Giovanni (contributor) - Centro de Referência em Informação Ambiental \
+Campbell Webb (contributor) - TDWG RDF/OWL Task Group \
+Paul J. Morris (contributor) - Harvard University Herbaria/Museum of Comparative Zoölogy \
+Mark Schildhauer (contributor) - National Center for Ecological Analysis and Synthesis \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** Darwin Core is a vocabulary standard for transmitting information about biodiversity. This document lists all terms in namespaces currently used in the vocabulary. \
+**Citation:** Darwin Core Maintenance Group. 2021. List of Darwin Core terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/list/2021-07-15
+
+**Title:** Degree of Establishment Controlled Vocabulary List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/doe/](https://dwc.tdwg.org/doe/) \
+**Created:** 2020-10-13 \
+**Last modified:** 2020-10-13 \
+**Contributors:** \
+Quentin Groom (lead author) - Botanic Garden Meise \
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform \
+Steve Baskauf (contributor) - Vanderbilt University Libraries \
+Arthur Chapman (contributor) - Australian Biodiversity Information Services \
+Melodie McGeoch (contributor) - McGeoch Research Group \
+Ramona Walls (contributor) - University of Arizona \
+John Wieczorek (contributor) - VertNet \
+John R.U. Wilson (contributor) - South African National Biodiversity Institute \
+Paula F F Zermoglio (contributor) - VertNet \
+Annie Simpson (contributor) - U.S. Geological Survey \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Darwin Core term degreeOfEstablishment provides information about degree to which an Organism survives, reproduces, and expands its range at the given place and time.. The Degree of Establishment Controlled Vocabulary provides terms that should be used as values for dwc:degreeOfEstablishment and dwciri:degreeOfEstablishment. \
+**Citation:** Darwin Core Maintenance Group. 2020. Degree of Establishment Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/doe/2020-10-13
+
+**Title:** Establishment Means Controlled Vocabulary List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/em/](https://dwc.tdwg.org/em/) \
+**Created:** 2020-10-13 \
+**Last modified:** 2020-10-13 \
+**Contributors:** \
+Quentin Groom (lead author) - Botanic Garden Meise \
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform \
+Steve Baskauf (contributor) - Vanderbilt University Libraries \
+Arthur Chapman (contributor) - Australian Biodiversity Information Services \
+Melodie McGeoch (contributor) - McGeoch Research Group \
+Ramona Walls (contributor) - University of Arizona \
+John Wieczorek (contributor) - VertNet \
+John R.U. Wilson (contributor) - South African National Biodiversity Institute \
+Paula F F Zermoglio (contributor) - VertNet \
+Annie Simpson (contributor) - U.S. Geological Survey \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Darwin Core term establishmentMeans provides information about whether an organism or organisms have been introduced to a given place and time through the direct or indirect activity of modern humans. The Establishment Means Controlled Vocabulary provides terms that should be used as values for dwc:establishmentMeans and dwciri:establishmentMeans. \
+**Citation:** Darwin Core Maintenance Group. 2020. Establishment Means Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/em/2020-10-13
+
+**Title:** Pathway Controlled Vocabulary List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/pw/](https://dwc.tdwg.org/pw/) \
+**Created:** 2020-10-13 \
+**Last modified:** 2020-10-13 \
+**Contributors:** \
+Quentin Groom (lead author) - Botanic Garden Meise \
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
+Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform \
+Steve Baskauf (contributor) - Vanderbilt University Libraries \
+Arthur Chapman (contributor) - Australian Biodiversity Information Services \
+Melodie McGeoch (contributor) - McGeoch Research Group \
+Ramona Walls (contributor) - University of Arizona \
+John Wieczorek (contributor) - VertNet \
+John R.U. Wilson (contributor) - South African National Biodiversity Institute \
+Paula F F Zermoglio (contributor) - VertNet \
+Annie Simpson (contributor) - U.S. Geological Survey \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Darwin Core term pathway provides information about the process by which an Organism came to be in a given place at a given time. The Pathway Controlled Vocabulary provides terms that should be used as values for dwc:pathway and dwciri:pathway. \
+**Citation:** Darwin Core Maintenance Group. 2020. Pathway Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/pw//2020-10-13
+
+**Title:** Chronometric Age Vocabulary List of Terms \
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/chrono/](https://tdwg.github.io/chrono/list/) \
+**Created:** 2021-04-27 \
+**Last modified:** 2021-04-27 \
+**Contributors:** \
+John Wieczorek (lead author) - VertNet \
+Laura Brenskelle (contributor) - University of Florida \
+Robert Guralnick (contributor) - University of Florida \
+Kitty Emery (contributor) - University of Florida \
+Michelle LeFebvre (contributor) - University of Florida \
+Neill Wallis (contributor) - University of Florida \
+Steve Baskauf (contributor) - Vanderbilt University Libraries \
+Marie Elise Lecoq (contributor) \
+Eric Kansa (contributor) - Harvard University \
+Sarah Kansa (contributor) - The Alexandria Archive Institute \
+Denné Reed (contributor) - University of Texas at Austin \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** The Chronometric Age Vocabulary is a standard for transmitting information about chronometric ages - the processes and results of an assay or other analysis used to determine the age of a MaterialSample. This document lists all terms in namespaces currently used in the vocabulary. \
+**Citation:** TDWG Darwin Core Chronometric Age Extension Task Group. 2021. Chronometric Age Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/chrono/2021-04-27
+

--- a/content/pages/standards/economic-botany/index.md
+++ b/content/pages/standards/economic-botany/index.md
@@ -15,23 +15,41 @@ website_title: Online version at kew.org
 Title
 : Economic Botany Data Collection Standard
 
-Date created
-: 1995-10-01
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/103>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
+: 1995
 
 Status
-: Prior standard
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Best current practice
-
-Permanent IRI
-: <http://www.tdwg.org/standards/103>
+: [Best current practice](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
 : Studies on the uses of plants are becoming increasingly important. Standardisation of terms and a unified system to describe uses are of enormous benefit to gatherers of information, especially where exchanges of data sets are involved. The standard provides a system whereby uses of plants (in their cultural context) can be described, using standardised descriptors and terms, and attached to taxonomic data sets. It resulted from discussions at the International Working Group on Taxonomic Databases for Plant Sciences (TDWG) between 1989 and 1992.
 
-Creator
-: Economic Botany Interest Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
-
 Bibliographic citation
-: > Cook FEM (1995) Economic Botany Data Collection Standard. Prepared for the International Working Group on Taxonomic Databases for Plant Sciences (TDWG). Kew: Royal Botanic Gardens, Kew, 1995. x + 146 pp. ISBN 0947643710
+: > TDWG Economic Botany Subgroup. 1995. Economic Botany Data Collection Standard. International Working Group on Taxonomic Databases for Plant Sciences (TDWG) http://www.tdwg.org/standards/103
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Economic Botany Data Collection Standard \
+**Permanent IRI:** [http://rs.tdwg.org/ebdc/doc/specification/](https://www.kew.org/tdwguses/index.htm) \
+**Created:** 1995 \
+**Last modified:** 1995 \
+**Contributors:** \
+Frances E. M. Cook (author) - Royal Botanic Gardens, Kew \
+**Publisher:** Royal Botanic Gardens, Kew \
+**Abstract:** The aim of the Economic Botany Data Collection Standard is to provide a system whereby uses of plants (in their cultural context) can be described, using standardised descriptors and terms, and attached to taxonomic data sets. This book describes the structure and implementation of the standard. \
+**Note:** This document was available in print.  The linked document is a scan of the print book. \
+**Citation:** Cook, Frances E. M. 1995. Economic Botany Data Collection Standard. Prepared for the International Working Group on Taxonomic Databases for Plant Sciences (TDWG) by the Royal Botanic Gardens, Kew. ISBN 0947643710.  http://rs.tdwg.org/ebdc/doc/specification/
+

--- a/content/pages/standards/floristic-regions/index.md
+++ b/content/pages/standards/floristic-regions/index.md
@@ -1,5 +1,5 @@
 ---
-title: Floristic regions of the world
+title: Floristic Regions of the World
 summary: Floristic Regions of the World by A. Takhtajan presents a widely accepted schema of biogeographical areas defined by environmental factors and floristic composition. It is a hierarchical schema that recognizes six floristic kingdoms, 35 floristic regions and 152 floristic provinces.
 cover_image: https://images.unsplash.com/photo-1511497584788-876760111969
 cover_image_by: Sergei Akulich
@@ -13,23 +13,40 @@ github: https://github.com/tdwg/prior-standards/tree/master/floristic-regions-of
 Title
 : Floristic Regions of the World
 
-Date created
-: 1986-10-01
-
-Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/104>
 
-Abstract
-: 
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: Armen Takhtajan
+Ratified
+: 1986
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Abstract
+: A book that describes the floristic divisions for the whole world, lists endemic families and genera, and provides examples of endemic species for each province
 
 Bibliographic citation
-: > Takhtajan A (1986) Floristic Regions of the World. University of California Press. Berkeley, Los Angeles, London. xxii, 522 pp., 4 maps. ISBN 0520040279
+: > Takhtajan, A. 1986. Floristic Regions of the World Standard. IUBS Commission for Plant Taxonomic Databases (TDWG) http://www.tdwg.org/standards/104
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Floristic Regions of the World \
+**Permanent IRI:** [http://rs.tdwg.org/frw/doc/book/](https://github.com/tdwg/prior-standards/tree/master/floristic-regions-of-the-world) \
+**Created:** 1986-09-04 \
+**Last modified:** 1986-09-04 \
+**Contributors:** \
+Armen Leonovich Takhtajan (author) \
+Theodore J. Crovello (translator) \
+Arthur Cronquist (editor) \
+**Publisher:** University of California Press  \
+**Abstract:** This book describes the floristic divisions for the whole world, lists endemic families and genera, and provides examples of endemic species for each province. \
+**Note:** First English Language Edition. Seems to be available in print only. \
+**Citation:** Takhtajan, A. L. 1986. Floristic Regions of the World. University of California Press. Berkeley, Los Angeles, London. xxii, 522 pp., 4 maps. ISBN 0520040279. http://rs.tdwg.org/frw/doc/book/
+

--- a/content/pages/standards/guid-as/index.md
+++ b/content/pages/standards/guid-as/index.md
@@ -1,5 +1,5 @@
 ---
-title: GUID applicability statements
+title: GUID and Life Sciences Identifiers Applicability Statements
 summary: The Global Unique Identifiers (GUID) applicability statements consist of an applicability statement on the use of GUIDs for the biodiversity information community in general ([Richards 2010]({static}tdwg_guid_applicability_statement.pdf)) and the use of Life Science Identifiers (LSID) in specific ([Pereira et al. 2009]({static}tdwg_lsid_applicability_statement.pdf)).
 cover_image: https://c2.staticflickr.com/4/3516/3701836175_5567871dc6_o.jpg
 cover_image_by: Erik de Vos
@@ -8,60 +8,62 @@ tags: applicability statement, current standard, 2011
 github: https://github.com/tdwg/guid-as
 ---
 
-## Header section for the GUID applicability statement
+## Header section
 
 Title
-: TDWG GUID Applicability Statement
+: GUID and Life Sciences Identifiers Applicability Statements
 
-Date created
-: 2010-09-09
-
-Status
-: Current standard
-
-Category
-: Applicability statement
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/150>
 
-Abstract
-: The TDWG GUID Applicability Statement 1) provides guidance on how to use GUIDs (Globally Unique Identifiers) to meet specific requirements of the biodiversity information community; 2) applies to GUIDs in general; there is, or will be, a separate document for the applicability of each specific GUID technology.
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Contributors
-: Kevin Richards (Landcare Research)
-
-Creator
-: Globally Unique Identifiers Task Group (GUID), [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
-
-Bibliographic citation
-: > Richards K (2010) TDWG GUID Applicability Statement, Version 2010-09. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/150>
-
-## Header section for the LSID applicability statement
-
-Title
-: TDWG Life Sciences Identifiers (LSID) Applicability Statement
-
-Date created
-: 2009-09-03
+Ratified
+: 2011-01-30
 
 Status
-: Current standard
+: [Current standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Applicability statement
-
-Permanent IRI
-: <http://www.tdwg.org/standards/150>
+: [Applicability statement](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
-: The TDWG Life Science Identifiers (LSID) applicability statement 1) is a specific GUID applicability statement that should be read in conjunction with the general GUID applicability statement; 2) provides guidance on how to use Life Science Identifiers (LSID) to meet specific requirements of the biodiversity information community; 3) defines how to identify shared data objects in biodiversity information applications using LSIDs.
-
-Contributors
-: Ricardo Pereira (TDWG Infrastructure Project), Kevin Richards (Landcare Research), Donald Hobern (Global Biodiversity Information Facility), Roger Hyam (TDWG Infrastructure Project), Lee Belbin (TDWG Infrastructure Project), Stan Blum (California Academy of Sciences)
-
-Creator
-: Globally Unique Identifiers Task Group (GUID), [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+: The TDWG GUID Applicability Statement 1) provides guidance on how to use GUIDs (Globally Unique Identifiers) to meet specific requirements of the biodiversity information community; 2) applies to GUIDs in general; there is, or will be, a separate document for the applicability of each specific GUID technology. The LSID (Life Sciences Applicability Statement) describes how to use that technology.
 
 Bibliographic citation
-: > Pereira R, Richards K, Hobern D, Hyam R, Belbin L, Blum S (2009) TDWG Life Sciences Identifiers (LSID) Applicability Statement, Version 2009-09. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/150>
+: > Globally Unique Identifiers Task Group. 2011. GUID and Life Sciences Identifiers Applicability Statements. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/150
+
+## Parts of the standard
+
+This standard is comprised of 2 documents. 
+
+Documents:
+
+**Title:** Globally Unique Identifiers Applicability Statement \
+**Permanent IRI:** [http://rs.tdwg.org/guid/doc/guidas/](https://github.com/tdwg/guid-as/blob/master/guid/tdwg_guid_applicability_statement.pdf) \
+**Created:** 2010-09-09 \
+**Last modified:** 2010-09-09 \
+**Contributors:** \
+Kevin Richards (lead author) - Landcare Research \
+Ben Richardson (review manager) - Department of Environment and Conservation, Western Australia \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document provides guidance on how to use GUIDs (Globally Unique Identifiers) to meet specific requirements of the biodiversity information community.  It applies to GUIDs in general; there is, or will be, a separate document for the applicability of each specific GUID technology. \
+**Citation:** Globally Unique Identifiers Task Group. 2011. Globally Unique Identifiers (GUID) Applicability Statement. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/guid/doc/guidas/
+
+**Title:** Life Sciences Identifiers (LSID) Applicability Statement \
+**Permanent IRI:** [http://rs.tdwg.org/guid/doc/lsidas/](https://github.com/tdwg/guid-as/blob/master/lsid/tdwg_lsid_applicability_statement.pdf) \
+**Created:** 2009-09-03 \
+**Last modified:** 2009-09-03 \
+**Contributors:** \
+Ricardo Scachetti-Pereira (author) - TDWG Infrastructure Project \
+Kevin Richards (author) - Landcare Research \
+Donald Hobern (author) - Global Biodiversity Information Facility \
+Roger Hyam (author) - TDWG Infrastructure Project \
+Lee Belbin (author) - TDWG Infrastructure Project \
+Stanley Blum (author) - California Academy of Sciences \
+Ben Richardson (review manager) - Department of Environment and Conservation, Western Australia \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document provides guidance on how to use LSID to meet specific requirements of the biodiversity information community; and defines how to identify shared data objects in biodiversity information applications using Life Sciences Identifiers (LSID). It should be read in conjunction with the GUID Applicability Statement \
+**Citation:** Globally Unique Identifiers Task Group. 2011. Life Science Identifiers (LSID) Applicability Statement. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/guid/doc/lsidas/
+

--- a/content/pages/standards/hispid3/index.md
+++ b/content/pages/standards/hispid3/index.md
@@ -15,23 +15,40 @@ website_title: HISPID3 at HISCOM
 Title
 : Herbarium Information Standards and Protocols for Interchange of Data (HISPID3)
 
-Date created
-: 1996-10-01
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/110>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
+: 1996
 
 Status
-: Prior standard
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/110>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
 : The 'Herbarium Information Standards and Protocols for Interchange of Data' (HISPID) is a standard format for the interchange of electronic herbarium specimen information. HISPID has been developed by a committee of representatives from all major Australian herbaria. This interchange standard was first published in 1989, with a revised version published in 1993. HISPID3 is an accession-based interchange standard. Although many fields refer to attributes of the taxon they should be construed as applying to the specimen represented by the record, not to the taxon per se. The interchange of taxonomic, nomenclatural, bibliographic, typification, rare and endangered plant conservation, and other related information is not dealt with in this standard, unless it specifically refers to a particular accession (record). This data dictionary is concerned primarily with data interchange standards but has considerable relevance to database structure since the task of preparing interchange files is simplified if the data fields of the despatching and receiving databases match, as far as possible, the interchange standard. If differences do exist then, generally, it is easier to combine data fields than it is to dissect them in a reliable manner. Fields that are concatenated are frequently heterogeneous in their nature and many preclude the possibility of rearranging the data contained within such fields. The fields discussed in this data dictionary cover most of the herbarium and botanic gardens sphere of activity and have been arranged in groups of similar types of information. In many cases these groups may coincide with separate well-defined tables (or databases) of structurally similar records. The challenge for herbarium data managers is to decide whether the data are to be efficiently exchanged as discrete but related tables (databases) or as a larger single flat file that may have to be appropriately dismembered by the receiving institution. Some database packages are able to stack multiple values in a single field. This useful data structure complicates the interchange format and will not be used at this stage.
 
-Creator
-: Observation and Specimen Records (OSR), [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
-
 Bibliographic citation
-: 
+: > Observation and Specimen Records. 1996. Herbarium Information Standards and Protocols for Interchange of Data (HISPID3) Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/110
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** HISPID3 Herbarium Information Standards and Protocols for Interchange of Data \
+**Permanent IRI:** [http://rs.tdwg.org/hispid/doc/specification/](https://raw.githack.com/tdwg/prior-standards/master/hispid3/110-540-1-RV.html) \
+**Created:** 1989 \
+**Last modified:** 2007-05-11 \
+**Contributors:** \
+Barry J. Conn (editor) \
+**Publisher:** Council of Heads of Australian Herbaria \
+**Abstract:** This document describes the form of HISPID3 records and the fields that can be included in an interchange flat file. \
+**Citation:** Herbarium Information Systems Committee. 2007. HISPID3 Herbarium Information Standards and Protocols for Interchange of Data. Council of Heads of Australian Herbaria. http://rs.tdwg.org/hispid/doc/specification/
+

--- a/content/pages/standards/ih/index.md
+++ b/content/pages/standards/ih/index.md
@@ -1,38 +1,50 @@
 ---
-title: Index herbariorum. Part 1, The herbaria of the world
-summary: 
-cover_image: 
-cover_image_by: 
-cover_image_ref: 
+title: Index Herbariorum. Part I: The Herbaria of the World
 tags: prior standard, 1990
 github: https://github.com/tdwg/prior-standards/tree/master/index-herbariorum-part-i
 website: http://sweetgum.nybg.org/science/ih/
 website_title: Current online version of Index Herbariorum
-status: hidden
 ---
 
 ## Header section
 
 Title
-: Index herbariorum. Part 1, The herbaria of the world
+: Index Herbariorum. Part I: The Herbaria of the World
 
-Date created
-: 1990-10-01
-
-Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/105>
 
-Abstract
-: 
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: 
+Ratified
+: 1990
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Abstract
+: A guide that records the physical location, holdings, and contact information of the world's herbaria.
 
 Bibliographic citation
-: > Holmgren PK, Holmgren NH, Barnett LC (1990) Index herbariorum. Part I, The herbaria of the world. 8th ed. New York: New York Botanical Garden for the International Association for Plant Taxonomy. Regnum vegetabile. 120.
+: > Holmgren, P. K., N. H. Holmgren, and L. C. Barnett. 1990. Index Herbariorum Standard. IUBS Commission for Plant Taxonomic Databases (TDWG) http://www.tdwg.org/standards/105
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Index Herbariorum. Part I: The Herbaria of the World (Regnum Vegetabile, Vol. 120, eighth edition) \
+**Permanent IRI:** [http://rs.tdwg.org/ih/doc/book/](http://sweetgum.nybg.org/science/ih/) \
+**Created:** 1990 \
+**Last modified:** 1990 \
+**Contributors:** \
+Patricia K. Holmgren (editor) \
+Noel H. Holmgren (editor) \
+Lisa C. Barnett (editor) \
+**Publisher:** New Your Botanical Gardens \
+**Abstract:** Index Herbariorum is a guide to the world's herbaria.  The Index Herbariorum (IH) entry for an herbarium includes its physical location, URL, contents (e.g., number and type of specimens), founding date, as well as names, contact information and areas of expertise of associated staff. Only those collections that are permanent scientific repositories are included in IH. \
+**Note:** Online database at http://sweetgum.nybg.org/science/ih/ \
+**Citation:** Holmgren, P. K., N. H. Holmgren, and L. C. Barnett. 1990. Index Herbariorum. Part I: The Herbaria of the World (Regnum Vegetabile, Vol. 120, eighth edition). New York Botanical Gardens. ISBN: 0893273589. http://rs.tdwg.org/ih/doc/book/
+

--- a/content/pages/standards/itf2/index.md
+++ b/content/pages/standards/itf2/index.md
@@ -13,23 +13,50 @@ github: https://github.com/tdwg/prior-standards/tree/master/itf2
 Title
 : International Transfer Format for Botanic Garden Plant Records (IFT2)
 
-Date created
-: 1987-10-01
-
-Status
-: Prior standard
-
-Category
-: Technical specification
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/102>
 
-Abstract
-: International Transfer Format for Botanic Garden Plant Records, version 2 (ITF2) was developed in response to requests from Botanic Gardens to incorporate additional data fields for transfer within the Botanic Gardens and allow for a more flexible transfer format than the original transfer format outlined in ITF version 01.00. It is biased towards 'Conservation Type Data Fields', but incorporates a procedure allowing for additional data fields to be identified and exchanged between gardens. It is because of this flexibility that it is believed that the ITF2 will remain relevant to Botanic Gardens for a long time despite the rapid change in information system technology in recent years. [BGCI](http://www.bgci.org/) was helped by international editorial committee, ran a number of International Workshops within the Botanic Garden Community and also consulted with internationally known horticultural Groups over the last 5 years produce this final draft of the International Transfer Format for Botanic Garden Records - Version 2 and it is hoped that others beyond the Botanic Garden Community will be able to make use of this publication. ITF2 was developed in close conjunction with [HISPID3](../hispid3/) (Herbarium Information Standards and Protocols for the Interchange of Data Version 3) and its progress has been closely monitored by the Centers of Plant Conservation (CPC) based in St Louis, Missouri, North American which is currently developing an data exchange format based on ITF2 but requiring additional fields unique to their network. It is fully compatible with ITF1 and has based its plantname structure on [Plant Names in Botanical Databases](../plant-names/), Frank A Bisby, Plant Taxonomic Database Standard No. 3 - Version 1.00, December 1994.
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: [Botanical Gardens Conservation International (BGCI)](http://www.bgci.org/)
+Ratified
+: 1987
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Category
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
+
+Abstract
+: International Transfer Format for Botanic Garden Plant Records, version 2 (ITF2) was developed in response to requests from Botanic Gardens to incorporate additional data fields for transfer within the Botanic Gardens and allow for a more flexible transfer format than the original transfer format outlined in ITF version 01.00. It is biased towards 'Conservation Type Data Fields', but incorporates a procedure allowing for additional data fields to be identified and exchanged between gardens. It is because of this flexibility that it is believed that the ITF2 will remain relevant to Botanic Gardens for a long time despite the rapid change in information system technology in recent years. BGCI (http://www.bgci.org/ ) was helped by international editorial committee, ran a number of International Workshops within the Botanic Garden Community and also consulted with internationally known horticultural Groups over the last 5 years produce this final draft of the International Transfer Format for Botanic Garden Records - Version 2 and it is hoped that others beyond the Botanic Garden Community will be able to make use of this publication. ITF2 was developed in close conjunction with HISPID3 (Herbarium Information Standards and Protocols for the Interchange of Data Version 3, http://www.tdwg.org/standards/110 ) and its progress has been closely monitored by the Centers of Plant Conservation (CPC) based in St Louis, Missouri, North American which is currently developing an data exchange format based on ITF2 but requiring additional fields unique to their network. It is fully compatible with ITF1 and has based its plantname structure on Plant Names in Botanical Databases (http://www.tdwg.org/standards/113 ), Frank A Bisby, Plant Taxonomic Database Standard No. 3 - Version 1.00, December 1994.
 
 Bibliographic citation
-: 
+: > Wyse Jackson, D., C. Hobson, B. Conn, R. Piacentini, S. Waldren, C. Ward, K. Bailey, P. Wyse Jackson, S. T. Wood, K. Walter. 1998. The International Transfer Format (ITF) for Botanic Garden Plant Records Standard. IUBS Commission for Plant Taxonomic Databases (TDWG) http://www.tdwg.org/standards/102
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** The International Transfer Format (ITF) for Botanic Garden Plant Records (Version 2) \
+**Permanent IRI:** [http://rs.tdwg.org/itfbgpr/doc/specification/](http://www.bgci.org/files/Databases/itf2.pdf) \
+**Created:** 1987-09-15 \
+**Last modified:** 1998 \
+**Contributors:** \
+Diane Wyse Jackson (lead author) - Botanic Gardens Conservation International \
+Christopher Hobson (editor) - Botanic Gardens Conservation International \
+Barry Conn (editor) - Botanic Gardens Conservation International \
+Richard Piacentini (editor) - Botanic Gardens Conservation International \
+Steve Waldren (editor) - Botanic Gardens Conservation International \
+Chris Ward (editor) - Botanic Gardens Conservation International \
+Ken Bailey (author) - Royal Botanic Garden, Kew \
+Peter Wyse Jackson (author) - Botanic Gardens Conservation International \
+Simon Thornton Wood (author) - Royal Horticultural Society \
+Kerry Walter (author) - BG-BASE and Royal Botanic Garden, Edinburgh \
+**Publisher:** Botanic Gardens Conservation International \
+**Abstract:** This document contains a complete description of version 2 of the International Transfer Format for Botanic Garden Records. It includes all the information which institutions will need when making use of the ITF2 to send or receive plant records in the ITF2 format. The annexes to this manual describe some of the problem areas which needed to be addressed during the definition of ITF2.  \
+**Note:** Available only in electronic format. \
+**Citation:** Wyse Jackson, D., C. Hobson, B. Conn, R. Piacentini, S. Waldren, C. Ward, K. Bailey, P. Wyse Jackson, S. T. Wood, K. Walter. 1998. The International Transfer Format (ITF) for Botanic Garden Plant Records (Version 2). Botanic Gardens Conservation International. http://rs.tdwg.org/itfbgpr/doc/specification/
+

--- a/content/pages/standards/plant-names-authors/index.md
+++ b/content/pages/standards/plant-names-authors/index.md
@@ -1,6 +1,6 @@
 ---
 title: Authors of Plant Names
-summary: An index of authors of plant scientific names. Includes flowering plants, gymnosperms, pteridophytes, bryophytes, algae, fungi and fossil plants. Full names, dates of birth and death when known, recommended abbreviations and groups in which names have been published, are given for each author. Authors of Plant Names has been incorporated into the [International Plant Names Index (IPNI)](http://www.ipni.org/). 
+summary: An index of authors of plant scientific names. Includes flowering plants, gymnosperms, pteridophytes, bryophytes, algae, fungi and fossil plants. Full names, dates of birth and death when known, recommended abbreviations and groups in which names have been published, are given for each author. Authors of Plant Names has been incorporated into the [International Plant Names Index (IPNI)](https://www.ipni.org/).
 cover_image: https://images.unsplash.com/photo-1530027644375-9c83053d392e
 cover_image_by: Xuan Nguyen
 cover_image_ref: https://unsplash.com/photos/v6V-hfxjboI
@@ -15,26 +15,23 @@ website_title: Authors of Plant Names at kew.org
 Title
 : Authors of Plant Names
 
-Date created
-: 1992-10-01
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/101>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
+: 1992
 
 Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
-: <http://www.tdwg.org/standards/101>
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Abstract
 : An index of authors of plant scientific names. Includes flowering plants, gymnosperms, pteridophytes, bryophytes, algae, fungi and fossil plants. Full names, dates of birth and death when known, recommended abbreviations and groups in which names have been published, are given for each author.
 
-Creator
-: Brummitt RK & Powell CE
-
 Bibliographic citation
-: > Brummitt RK & Powell CE (eds) (1992) Authors of plant names. A list of authors of scientific names of plants, with recommended standard form of their names including abbreviations. Royal Botanic Gardens, Kew. Pp [4], 732. ISBN 0947643443
+: > Brummitt, R. K. and C. E. Powell. 1992. Authors of Plant Names Standard. International Working Group on Taxonomic Databases (TDWG) http://www.tdwg.org/standards/101
 
 ## Where is the Brummitt & Powell "Authors of Plant Names" database?
 
@@ -43,3 +40,22 @@ Since 1998 the database of author names and their standard forms (which formed t
 ## Authors of Plant Names and TDWG
 
 The Taxonomic Databases Working Group (TDWG) adopted the original printed version of Brummitt & Powell (1992) as their data standard for Authors of Plant Names. The adoption of the current live database is still currently under discussion. This would represent a new precedent for TDWG in that all standards adopted to date have been static and in hard copy.
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Authors of Plant Names \
+**Permanent IRI:** [http://rs.tdwg.org/apn/doc/data/](https://www.kew.org/data/authors.html) \
+**Created:** 1992 \
+**Last modified:** 1992 \
+**Contributors:** \
+Richard K. Brummitt (author) \
+C. Emma Powell (author) \
+**Publisher:** Royal Botanic Gardens, Kew \
+**Abstract:** An index of authors of plant scientific names. Includes flowering plants, gymnosperms, pteridophytes, bryophytes, algae, fungi and fossil plants. Full names, dates of birth and death when known, recommended abbreviations and groups in which names have been published, are given for each author.  \
+**Note:** Note: Authors of Plant Names eBook is behind a GBP 60 paywall (http://shop.kew.org/authors-of-plant-names-11770).  Since 1998, the database of author names and their standard forms has been maintained and updated online as part of The International Plant Names Index (http://www.ipni.org/). \
+**Citation:** Brummitt, R. K. and C. E. Powell. 1992. Authors of Plant Names. Kew Publishing. ISBN: 1842460854 http://rs.tdwg.org/apn/doc/data/1992
+

--- a/content/pages/standards/plant-names/index.md
+++ b/content/pages/standards/plant-names/index.md
@@ -6,7 +6,6 @@ cover_image_by: Micheile Henderson
 cover_image_ref: https://unsplash.com/photos/DV4lEwcj774
 tags: prior standard, 1995
 github: https://github.com/tdwg/prior-standards/tree/master/plant-names-in-botanical-databases
-status: hidden
 ---
 
 ## Header section
@@ -14,23 +13,41 @@ status: hidden
 Title
 : Plant Names in Botanical Databases
 
-Date created
-: 1995-10-01
-
-Status
-: Prior standard
-
-Category
-: Best current practice
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/113>
 
-Abstract
-: This standard defines the taxonomic and nomenclatural concepts associated with the names of plants. It describes the component parts, their functions and their interrelations of significance in structuring a database. The appendices provide an outline of a preliminary data dictionary illustrating possible elements and their properties. It does not provide a data model or a data format. A data model will be considered at a later date by the TDWG Sub-group considering this standard. Another TDWG Sub-group is preparing [XDF](../xdf/), an EXchange Data Format (Allkin & White,1989; White & Allkin, 1992), which provides a language for defining a range of exchange formats for use between taxonomic databases.
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: 
+Ratified
+: 1995
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Category
+: [Best current practice](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
+
+Abstract
+: This standard defines the taxonomic and nomenclatural concepts associated with the names of plants. It describes the component parts, their functions and their interrelations of significance in structuring a database. The appendices provide an outline of a preliminary data dictionary illustrating possible elements and their properties. It does not provide a data model or a data format. A data model will be considered at a later date by the TDWG Sub-group considering this standard. Another TDWG Sub-group is preparing XDF (http://www.tdwg.org/standards/108 ), an EXchange Data Format (Allkin & White,1989; White & Allkin, 1992), which provides a language for defining a range of exchange formats for use between taxonomic databases.
 
 Bibliographic citation
-: 
+: > TDWG Minimum Standard for Names in Botanical Databases Subgroup. 1995. Plant Names in Botanical Databases. International Working Group on Taxonomic Databases (TDWG) http://www.tdwg.org/standards/106
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Plant Names in Botanical Databases \
+**Permanent IRI:** [http://rs.tdwg.org/pnbd/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/plant-names-in-botanical-databases/113-528-1-RV.pdf) \
+**Created:** 1994-12 \
+**Last modified:** 1994-12 \
+**Contributors:** \
+Frank A Bisby  (author) - University of Southampton  \
+**Publisher:** Hunt Institute for Botanical Documentation \
+**Abstract:** This standard defines the taxonomic and nomenclatural concepts associated with the names of plants. It describes the component parts, their functions and their interrelations of significance in structuring a database.  \
+**Note:** Note: the introduction of this publication provides some historical information about TDWG and early standards it produced or adopted from elsewhere. \
+**Citation:** TDWG Minimum Standard for Names in Botanical Databases Subgroup (Author: Frank A. Bisby). 1994. Plant Names in Botanical Databases. Hunt Institute for Botanical Documentation. http://rs.tdwg.org/pnbd/doc/specification/
+

--- a/content/pages/standards/poss/index.md
+++ b/content/pages/standards/poss/index.md
@@ -13,23 +13,37 @@ github: https://github.com/tdwg/prior-standards/tree/master/poss
 Title
 : Plant Occurrence and Status Scheme (POSS)
 
-Date created
-: 1995-10-01
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/106>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
+: 1995
 
 Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
-: <http://www.tdwg.org/standards/106>
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Abstract
 : The Plant Occurrence and Status Scheme (POSS) has been developed to provide standard terms for recording the occurrence of a plant taxon for a specific location. As with all standards, POSS aims to provide both a clear, unambiguous framework for information management, and at the same time provides a mechanism for information exchange. It is worth noting, that although the standard has been developed with the management of plant information in mind, the standard is equally suitable for the management of animal information, although animal movement and migration are not provided for.
 
-Creator
-: [World Conservation Monitoring Centre](https://www.unep-wcmc.org/)
-
 Bibliographic citation
-: 
+: > World Conservation Monitoring Centre. 1995. Plant Occurrence and Status Scheme: A Standard for Recording the Relationship between a Plant and a Place. International Working Group on Taxonomic Databases (TDWG) http://www.tdwg.org/standards/106
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** Plant Occurrence and Status Scheme: A Standard for Recording the Relationship between a Plant and a Place \
+**Permanent IRI:** [http://rs.tdwg.org/poss/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/poss/106-522-1-RV.pdf) \
+**Created:** 1995-11 \
+**Last modified:** 1995-11 \
+**Contributors:** \
+Hugh Synge (author) - IUCN Conservation Monitoring Centre \
+**Publisher:** International Working Group on Taxonomic Databases (TDWG) \
+**Abstract:** This document describes the general principles of POSS and describes the data fields and their suggested values. \
+**Citation:** World Conservation Monitoring Centre. 1995. Plant Occurrence and Status Scheme: A Standard for Recording the Relationship between a Plant and a Place. International Working Group on Taxonomic Databases (TDWG). http://rs.tdwg.org/poss/doc/specification/
+

--- a/content/pages/standards/sdd/index.md
+++ b/content/pages/standards/sdd/index.md
@@ -13,23 +13,56 @@ github: https://github.com/tdwg/sdd
 Title
 : Structured Descriptive Data (SDD)
 
-Date created
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/116>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2005-09-16
 
 Status
-: Current (2005) standard
+: [Current (2005) standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <https://www.tdwg.org/standards/116>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
-: In taxonomy, descriptive data takes a number of very different forms. Natural-language descriptions are semi-structured, semi-formalised descriptions of a taxon (or occasionally of an individual specimen). They may be simple, short and written in plain language (if used for a popular field guide), or long, highly formal and using specialised terminology when used in a taxonomic monograph or other treatment. Dichotomous keys are specialised identification tools comprising fragments of descriptive data arranged in couplets forming a branching tree. Each fragment (lead) comprises a small (occasionally verbose) natural-language description. Raw data descriptions usually comprise repeated measurements of parts of individual specimens, and are the basis from which the more abstracted descriptions in natural language and coded descriptions are derived. Few taxonomists consistently record and archive their raw data in a standardised format. The goal of the SDD standard is to allow capture, transport, caching and archiving of descriptive data in all the forms shown above, using a platform- and application-independent, international standard. Such a standard is crucial to enabling lossless porting of data between existing and future software platforms including identification, data-mining and analysis tools, and federated databases.
-
-Creator
-: Biological Descriptions Interest Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+: In taxonomy, descriptive data takes a number of very different forms. Natural-language descriptions are semi-structured, semi-formalised descriptions of a taxon (or occasionally of an individual specimen). They may be simple, short and written in plain language (if used for a popular field guide), or long, highly formal and using specialised terminology when used in a taxonomic monograph or other treatment. Dichotomous keys are specialised identification tools comprising fragments of descriptive data arranged in couplets forming a branching tree. Each fragment (lead) comprises a small (occasionally verbose) natural-language description. Raw data descriptions usually comprise repeated measurements of parts of individual specimens, and are the basis from which the more abstracted descriptions in natural language and coded descriptions are derived. Few taxonomists consistently record and archive their raw data in a standardised format. The goal of the SDD standard is to allow capture, transport, caching and archiving of descriptive data in all the forms shown above, using a platform- and application-independent, XML-based international standard. Such a standard is crucial to enabling lossless porting of data between existing and future software platforms including identification, data-mining and analysis tools, and federated databases.
 
 Bibliographic citation
-: > Hagedorn G, Thiele K, Morris R, Heidorn PB (2005) Structured Descriptive Data (SDD) w3c-xml-schema, Version 1.0. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/116>
+: > Structure of Descriptive Data Subgroup. 2005. Structured Descriptive Data (SDD). Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/116
+
+## Parts of the standard
+
+This standard is comprised of 2 documents. 
+
+Documents:
+
+**Title:** Introduction and Primer to the Structured Descriptive Data (SDD) Standard \
+**Permanent IRI:** [http://rs.tdwg.org/sdd/doc/introduction/](https://github.com/tdwg/wiki-archive/blob/master/twiki/data/SDD/Primer/SddIntroduction.txt) \
+**Created:** 2006-05-11 \
+**Last modified:** 2006-05-11 \
+**Contributors:** \
+Gregor Hagedorn (author) - Julius Kühn Institute  \
+Kevin R. Thiele (author) - Western Australian Herbarium  \
+Robert A. Morris (author) - University of Massachusetts at Boston, USA \
+P. Bryan Heidorn (author) - University of Illinois at Urbana-Champaign \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document is a non-normative introduction to the Taxonomic Databases Working Group SDD (Structure of Descriptive Data) Standard. Its intention is to provide a background, introduction and primer to the SDD Standard, with examples. \
+**Citation:** Structure of Descriptive Data (SDD) Subgroup. 2006. Introduction and Primer to the Structured Descriptive Data (SDD) Standard. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/sdd/doc/introduction/
+
+**Title:** Structured Descriptive Data XML Schema \
+**Permanent IRI:** [http://rs.tdwg.org/sdd/doc/xmlschema/](https://github.com/tdwg/sdd/blob/master/2006/Schema/1.1/SDD.xsd) \
+**Created:** 2006-05-11 \
+**Last modified:** 2006-05-11 \
+**Contributors:** \
+Gregor Hagedorn (author) - Julius Kühn Institute  \
+Kevin R. Thiele (author) - Western Australian Herbarium  \
+Robert A. Morris (author) - University of Massachusetts at Boston, USA \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This is the schema file to be referenced in instance documents for validation. It is the top level schema file that integrates the schema components.  \
+**Note:** See also https://raw.githack.com/tdwg/sdd/master/2006/rddl.html and https://github.com/tdwg/sdd/blob/master/2006/Schema/1.1/UBIF_(c).xsd \
+**Citation:** Structure of Descriptive Data (SDD) Subgroup. 2006. Structured Descriptive Data XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/sdd/doc/xmlschema/
+

--- a/content/pages/standards/sds/index.md
+++ b/content/pages/standards/sds/index.md
@@ -1,6 +1,6 @@
 ---
 title: TDWG Standards Documentation Standard (SDS)
-summary: “The TDWG Standards Documentation Standard (SDS) consists of a single document: the [Standards Documentation Specification](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md). That document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms.”
+summary: "The TDWG Standards Documentation Standard (SDS) consists of a single document: the [Standards Documentation Specification](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md). That document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms."
 cover_image: https://images.unsplash.com/photo-1497796742626-fe30f204ec54
 cover_image_by: Lysander Yuen
 cover_image_ref: https://unsplash.com/photos/wk833OrQLJE

--- a/content/pages/standards/sds/index.md
+++ b/content/pages/standards/sds/index.md
@@ -1,6 +1,6 @@
 ---
 title: TDWG Standards Documentation Standard (SDS)
-summary: "The TDWG Standards Documentation Standard (SDS) consists of a single document: the [Standards Documentation Specification](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md). That document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms."
+summary: “The TDWG Standards Documentation Standard (SDS) consists of a single document: the [Standards Documentation Specification](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md). That document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms.”
 cover_image: https://images.unsplash.com/photo-1497796742626-fe30f204ec54
 cover_image_by: Lysander Yuen
 cover_image_ref: https://unsplash.com/photos/wk833OrQLJE
@@ -11,39 +11,50 @@ github: https://github.com/tdwg/vocab/tree/master/sds
 ## Header section
 
 Title
-: Standards Documentation Standard
+: TDWG Standards Documentation Standard (SDS)
 
-Date ratified
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/147>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2017-04-25
 
 Status
-: Current standard
+: [Current standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/147>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
-: The TDWG Standards Documentation Standard consists of a single document: the [Standards Documentation Specification](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md). That document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms.
-
-Contributors
-: Contributors: Steve Baskauf (TDWG Vocabulary Maintenance Specification Task Group), Roger Hyam (TDWG Infrastructure Project), Stanley Blum (TDWG Process Interest Group), Robert A. Morris (UMASS-Boston, TDWG Imaging Interest Group), Jonathan Rees (Duke University), Joel Sachs (TDWG RDF Task Group), Greg Whitbread (TDWG Technical Architecture Group), John Wieczorek (TDWG Darwin Core Task Group). Review manager: Dag Endresen (GBIF Norway/NHM University of Oslo)
-
-Creator
-: Vocabulary Maintenance Specification Task Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+: The TDWG Standards Documentation Standard consists of a single document: the Standards Documentation Specification. That document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms.
 
 Bibliographic citation
-: > Vocabulary Maintenance Specification Task Group (2017) Standards Documentation Standard (Endresen D, review manager). Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/147>
+: > Vocabulary Maintenance Specification Task Group. 2017. Standards Documentation Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/147
 
 ## Parts of the standard
 
-The TDWG Standards Documentation Standard is described by a single document, the Standards Documentation Specification.
+This standard is comprised of one document. 
 
-- It is viewable in human-readable form at:
-<https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md>
-- It is available in Markdown format at: <https://raw.githubusercontent.com/tdwg/vocab/master/sds/documentation-specification.md>
-- Its machine-readable metadata are available in RDF/Turtle serialization at:
-<https://raw.githubusercontent.com/tdwg/vocab/master/sds/documentation-specification.ttl>
+Documents:
+
+**Title:** Standards Documentation Specification \
+**Permanent IRI:** [http://rs.tdwg.org/sds/doc/specification/](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md) \
+**Created:** 2007-11-05 \
+**Last modified:** 2017-04-25 \
+**Contributors:** \
+Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group \
+Roger Hyam (author) - TDWG Infrastructure Project \
+Stanley Blum (author) - TDWG Process Interest Group \
+Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group \
+Jonathan Rees (author) - Duke University \
+Joel Sachs (author) - TDWG RDF Task Group \
+Greg Whitbread (author) - TDWG Technical Architecture Group \
+John Wieczorek (author) - TDWG Darwin Core Task Group \
+Dag Endresen (review manager) - GBIF Norway/NHM University of Oslo \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms. \
+**Citation:** Vocabulary Maintenance Specification Task Group. 2017. Standards Documentation Specification. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/sds/doc/specification/
 

--- a/content/pages/standards/tapir/index.md
+++ b/content/pages/standards/tapir/index.md
@@ -13,28 +13,28 @@ website_title: TAPIR specification
 ## Header section
 
 Title
-: TAPIR - TDWG Access Protocol for Information Retrieval
+: TDWG Access Protocol for Information Retrieval (TAPIR)
 
-Date created
-: 2010-05-05
-
-Status
-: Current standard
-
-Category
-: Technical specification
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/449>
 
-Abstract
-: TAPIR is a computer protocol designed for discovery, search and retrieval of distributed data over the Internet. TAPIR consists of a [specification](http://tdwg.github.io/tapir/docs/) that determines how client applications seeking information should communicate with server applications hosting data. TAPIR is an approved TDWG standard.
-
-Creator
+Publisher
 : [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
+Ratified
+: 2009-09-09
+
+Status
+: [Current standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Category
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
+
+Abstract
+: TAPIR is a computer protocol designed for discovery, search and retrieval of distributed data over the Internet. TAPIR consists of a specification that determines how client applications seeking information should communicate with server applications hosting data. TAPIR is an approved TDWG standard.
+
 Bibliographic citation
-: > De Giovanni R, Döring M, Güntsch A, Vieglais D, Hobern D, de la Torre J, Wieczorek J, Gales R, Hyam R, Blum S, Perry S (2010) TDWG Access Protocol for Information Retrieval (TAPIR), Version 1.0. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/449>
+: > TAPIR Task Group. 2009. TDWG Access Protocol for Information Retrieval (TAPIR). Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/449
 
 ## Motivation
 
@@ -77,4 +77,76 @@ TAPIR is flexible enough to be used in a wide range of applications. Other examp
 <http://sourceforge.net/p/digir/svn/HEAD/tree/pywrapper/>
 - **TAPIR Tester**: <http://sourceforge.net/p/digir/svn/HEAD/tree/tapirtester/>
 - **TAPIR Builder**: <http://sourceforge.net/p/digir/svn/HEAD/tree/tapirbuilder/>
+
+
+## Parts of the standard
+
+This standard is comprised of 6 documents. 
+
+Documents:
+
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Protocol Specification \
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/specification/](http://tdwg.github.io/tapir/docs/tdwg_tapir_specification_2010-05-05.html) \
+**Created:** 2010-05-05 \
+**Last modified:** 2010-05-05 \
+**Contributors:** \
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
+Charles Copp (lead author) - Environmental Information Management  \
+Markus Döring (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+Anton Güntsch (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+Dave Vieglais (author) - KU Natural History Museum \
+Donald Hobern (author) - Global Biodiversity Information Facility \
+Javier de la Torre (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+John Wieczorek (author) - Museum of Vertebrate Zoology at Berkeley \
+Robert Gales (author) - KU Natural History Museum \
+Roger Hyam (author) - TDWG \
+Stanley Blum (author) - California Academy of Sciences \
+Perry Steven (author) - KU Natural History Museum \
+Piers Higgs (review manager) \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document specifies the TAPIR protocol and the structure and syntax of TAPIR messages.   \
+**Citation:** TAPIR Task Group. 2010. TDWG Access Protocol for Information Retrieval (TAPIR) Protocol Specification. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/specification/
+
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) XML Schema  \
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/xmlschema/](http://tdwg.github.io/tapir/schema/tapir.xsd) \
+**Created:** 2009-02-05 \
+**Last modified:** 2009-02-05 \
+**Contributors:** \
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** TAPIR XML Schema. TAPIR is an acronym for TDWG Access Protocol for Information Retrieval. It is a unified and extended protocol based on DiGIR and BioCASe. TAPIR specifies a standardised, stateless, HTTP transmittable, XML-based request and response protocol for accessing structured data that may be stored on any number of distributed databases of varied physical and logical structure.   \
+**Citation:** TAPIR Task Group. 2009. TDWG Access Protocol for Information Retrieval (TAPIR) XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/xmlschema/
+
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Concept Aliases \
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/conceptaliases/](http://tdwg.github.io/tapir/cns/alias.txt) \
+**Created:** 2015-06-01 \
+**Last modified:** 2015-06-01 \
+**Contributors:** \
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** Globally unique aliases for concepts. The aliases listed here are only unique within their concept source.  \
+**Citation:** TAPIR Task Group. 2015. TDWG Access Protocol for Information Retrieval (TAPIR) Concept Aliases. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/conceptaliases/
+
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Network Builders' Guide \
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/guide/](http://tdwg.github.io/tapir/docs/TAPIRNetworkBuildersGuide_2010-05-05.html) \
+**Created:** 2015-06-03 \
+**Last modified:** 2015-06-03 \
+**Contributors:** \
+Charles Copp (lead author) - Environmental Information Management  \
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
+Lee Belbin (reviewer) - TDWG Infrastructure Project \
+Markus Döring (reviewer) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document provides guidelines for building networks based on the TAPIR protocol.   \
+**Citation:** TAPIR Task Group. 2015. TDWG Access Protocol for Information Retrieval (TAPIR) Network Builders' Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/guide/
+
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Output Models and Query Templates \
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/models/](http://tdwg.github.io/tapir/cs/) \
+**Created:** 2015-11-25 \
+**Last modified:** 2015-11-25 \
+**Contributors:** \
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This page is an index to TAPIR XML models and query templates. \
+**Citation:** TAPIR Task Group. 2015. TDWG Access Protocol for Information Retrieval (TAPIR) Output Models and Query Templates. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/models/
 

--- a/content/pages/standards/tcs/index.md
+++ b/content/pages/standards/tcs/index.md
@@ -13,23 +13,55 @@ github: https://github.com/tdwg/tcs
 Title
 : Taxonomic Concept Transfer Schema (TCS)
 
-Date created
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/117>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2005-09-16
 
 Status
-: Current (2005) standard
+: [Current (2005) standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Technical specification
-
-Permanent IRI
-: <http://www.tdwg.org/standards/117>
+: [Technical specification](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
 : The TCS schema was conceived to allow the representation of taxonomic concepts as defined in published taxonomic classifications, revisions and databases. As such, it specifies the structure for XML documents to be used for the transfer of defined concepts. Valid transfer documents may either explicitly detail the defining components of taxon concepts, transfer GUIDs referring to defined taxon concepts (if and when these are available) or a mixture of the two.
 
-Creator
-: Taxonomic Names and Concepts Interest Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
-
 Bibliographic citation
-: > Taxonomic Names and Concepts Interest Group (2006) Taxonomic Concept Transfer Schema (TCS), version 1.01. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/117>
+: > Taxonomic Names and Concepts Interest Group. 2005. Taxonomic Concept Transfer Schema (TCS). Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/117
+
+## Maintenance group  
+TCS is maintained by the [Taxonomic Names and Concepts Interest Group](https://www.tdwg.org/community/tnc/), which has sponsored a Task Group to update TCS to make it compliant with the Standards Documentation Specification and to move it into the Current Standard category.
+
+## Parts of the standard
+
+This standard is comprised of 2 documents. 
+
+Documents:
+
+**Title:** Taxon Concept Schema User Guide \
+**Permanent IRI:** [http://rs.tdwg.org/tcs/doc/guide/](https://github.com/tdwg/tcs/blob/master/TCS101/UserGuidev_1.3.pdf) \
+**Created:** 2006-09-21 \
+**Last modified:** 2006-09-21 \
+**Contributors:** \
+Jessie Kennedy (author) - Napier University  \
+Roger Hyam (author) - TDWG Infrastructure Project \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This guide is meant to act as a readable introduction to the Taxon Concept Schema (TCS). It is aimed at both decision makers and implementers of systems and so the content varies from being of a general nature, assuming little prior knowledge of taxonomy or XML technologies, to being quite detailed concerning the technicalities of biological nomenclature and XML schemas. Generally it becomes more specific as it goes on. This document is not a step by step manual for mapping a data source to a TCS document. Each data source is likely to be different in structure and so this is not a feasible exercise. What it attempts to do is provided the information needed for an implementer to make intelligent decisions as to how their data source should be mapped to the schema so that they can publish and/or receive data from other systems with as little confusion as possible.  \
+**Citation:** Taxonomic Names Subgroup. 2006. Taxon Concept Schema User Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tcs/doc/guide/
+
+**Title:** Taxon Concept Schema XML Schema \
+**Permanent IRI:** [http://rs.tdwg.org/tcs/doc/xmlschema/](https://github.com/tdwg/tcs/blob/master/TCS101/v101.xsd) \
+**Created:** 2006-09-21 \
+**Last modified:** 2006-09-21 \
+**Contributors:** \
+Jessie Kennedy (author) - Napier University  \
+Roger Hyam (author) - TDWG Infrastructure Project \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document is the validation schema for Taxon Concept Schema XML documents. \
+**Citation:** Taxonomic Names Subgroup. 2006. Taxon Concept Schema XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tcs/doc/xmlschema/
+

--- a/content/pages/standards/tl-2/index.md
+++ b/content/pages/standards/tl-2/index.md
@@ -1,6 +1,6 @@
 ---
-title: Taxonomic Literature (TL-2)
-summary: "TL-2 is the premier publication of the [International Association for Plant Taxonomy (IAPT)](https://www.iaptglobal.org/) and [its online version](http://www.sil.si.edu/DigitalCollections/tl-2/) was made possible by the generous cooperation of the IAPT. In its print form, TL-2 is a 15 volume guide to the literature of systematic botany published between 1753 and 1940. It is organized by author and includes numbered entries for the author's publications. Suggested abbreviations for use in taxonomic publications are provided: abbreviations for the author's name, short titles and abbreviations of the short titles for publications. TL-2 is the standard by which authors' names and titles should be abbreviated."
+title: Taxonomic Literature, Edition 2 and its Supplements (TL-2)
+summary: “TL-2 is the premier publication of the [International Association for Plant Taxonomy (IAPT)](https://www.iaptglobal.org/) and [its online version](http://www.sil.si.edu/DigitalCollections/tl-2/) was made possible by the generous cooperation of the IAPT. In its print form, TL-2 is a 15 volume guide to the literature of systematic botany published between 1753 and 1940. It is organized by author and includes numbered entries for the author's publications. Suggested abbreviations for use in taxonomic publications are provided: abbreviations for the author's name, short titles and abbreviations of the short titles for publications. TL-2 is the standard by which authors' names and titles should be abbreviated.”
 cover_image: https://c1.staticflickr.com/9/8214/8291301344_c813b42546_b.jpg
 cover_image_by: Biodiversity Heritage Library
 cover_image_ref: https://www.flickr.com/photos/biodivlibrary/8291301344
@@ -13,26 +13,209 @@ website_title: Online version at Smithsonian Libraries
 ## Header section
 
 Title
-: Taxonomic Literature II (TL-2)
+: Taxonomic Literature, Edition 2 and its Supplements (TL-2)
 
-Date created
-: 1976-10-01
-
-Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/111>
 
-Abstract
-: TL-2 is the premier publication of the [International Association for Plant Taxonomy (IAPT)](https://www.iaptglobal.org/) and [its online version](http://www.sil.si.edu/DigitalCollections/tl-2/) was made possible by the generous cooperation of the IAPT. In its print form, TL-2 is a 15 volume guide to the literature of systematic botany published between 1753 and 1940. It is organized by author and includes numbered entries for the author's publications. Suggested abbreviations for use in taxonomic publications are provided: abbreviations for the author's name, short titles and abbreviations of the short titles for publications. TL-2 is the standard by which authors' names and titles should be abbreviated.
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: [International Association for Plant Taxonomy (IAPT)](https://www.iaptglobal.org/)
+Ratified
+: 1976
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Abstract
+: TL-2 is the premier publication of the International Association for Plant Taxonomy (IAPT, https://www.iaptglobal.org/ ) and its online version (http://www.sil.si.edu/DigitalCollections/tl-2/ ) was made possible by the generous cooperation of the IAPT. In its print form, TL-2 is a 15 volume guide to the literature of systematic botany published between 1753 and 1940. It is organized by author and includes numbered entries for the author's publications. Suggested abbreviations for use in taxonomic publications are provided: abbreviations for the author's name, short titles and abbreviations of the short titles for publications. TL-2 is the standard by which authors' names and titles should be abbreviated.
 
 Bibliographic citation
-: 
+: > International Association for Plant Taxonomy. 1976. Taxonomic Literature Standard. IUBS Commission for Plant Taxonomic Databases (TDWG) http://www.tdwg.org/standards/111
+
+## Parts of the standard
+
+This standard is comprised of 15 documents. 
+
+Documents:
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 1) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v1/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1976 \
+**Last modified:** 1976 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors A-G. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1976. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 1). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v1/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 2) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v2/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1979 \
+**Last modified:** 1979 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors H-Le. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1979. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 2). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v2/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 3) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v3/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1981 \
+**Last modified:** 1981 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors Lh-O. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1981. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 3). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v3/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 4) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v4/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1983 \
+**Last modified:** 1983 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors P-Sak. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1983. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 4). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v4/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 5) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v5/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1985 \
+**Last modified:** 1985 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors Sal-Ste. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1985. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 5). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v5/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 6) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v6/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1986 \
+**Last modified:** 1986 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors Sti-Vuy. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1986. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 6). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v6/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 7) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v7/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1988 \
+**Last modified:** 1988 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Richard S. Cowan (author) \
+**Publisher:** Bohn, Scheltema, and Holkema \
+**Abstract:** Authors W-Z. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and R. S. Cowan. 1988. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 7). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v7/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 1) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s1/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1992 \
+**Last modified:** 1992 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Erik A. Mennega (author) \
+**Publisher:** Koeltz Scientific Books \
+**Abstract:** Authors A-Ba. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and E. A. Mennega. 1992. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 1). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s1/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 2) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s2/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1993 \
+**Last modified:** 1993 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Erik A. Mennega (author) \
+**Publisher:** Koeltz Scientific Books \
+**Abstract:** Authors Be-Bo. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and E. A. Mennega. 1993. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 2). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s2/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 3) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s3/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1995 \
+**Last modified:** 1995 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Erik A. Mennega (author) \
+**Publisher:** Koeltz Scientific Books \
+**Abstract:** Authors Br-Ca. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and E. A. Mennega. 1995. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 3). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s3/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 4) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s4/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1997 \
+**Last modified:** 1997 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Erik A. Mennega (author) \
+**Publisher:** Koeltz Scientific Books \
+**Abstract:** Authors Ce-Cz. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and E. A. Mennega. 1997. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 4). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s4/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 5) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s5/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 1998 \
+**Last modified:** 1998 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Erik A. Mennega (author) \
+**Publisher:** Koeltz Scientific Books \
+**Abstract:** Authors Da-Di. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and E. A. Mennega. 1998. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 5). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s5/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 6) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s6/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 2000 \
+**Last modified:** 2000 \
+**Contributors:** \
+Frans A. Stafleu (lead author) \
+Erik A. Mennega (author) \
+**Publisher:** Koeltz Scientific Books \
+**Abstract:** Authors Do-E. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Stafleu, F. A. and E. A. Mennega. 2000. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 6). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s6/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 7) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s7/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 2008 \
+**Last modified:** 2008 \
+**Contributors:** \
+Laurence J. Dorr (author) \
+Dan H. Nicolson (author) \
+**Publisher:** A.R.G. Gantner Verlag K.G. \
+**Abstract:** Authors F-Frer. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Dorr, L. J. and D. H. Nicolson. 2008. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 7). A.R.G. Gantner Verlag K.G. http://rs.tdwg.org/tl/doc/s7/
+
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 8) \
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s8/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
+**Created:** 2009 \
+**Last modified:** 2009 \
+**Contributors:** \
+Laurence J. Dorr (author) \
+Dan H. Nicolson (author) \
+**Publisher:** A.R.G. Gantner Verlag K.G. \
+**Abstract:** Authors Fres-G. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Citation:** Dorr, L. J. and D. H. Nicolson. 2009. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 8). A.R.G. Gantner Verlag K.G. http://rs.tdwg.org/tl/doc/s8/
 

--- a/content/pages/standards/vms/index.md
+++ b/content/pages/standards/vms/index.md
@@ -11,31 +11,28 @@ github: https://github.com/tdwg/vocab/tree/master/vms
 ## Header section
 
 Title
-: Vocabulary Maintenance Standard
+: Vocabulary Maintenance Standard (VMS)
 
-Date ratified
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/642>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
 : 2017-04-25
 
 Status
-: Current standard
+: [Current standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Category
-: Best current practice
-
-Permanent IRI
-: <http://www.tdwg.org/standards/642>
+: [Best current practice](https://www.tdwg.org/standards/status-and-categories/#categories%20of%20tdwg%20standards_1)
 
 Abstract
-: The TDWG Vocabulary Maintenance Standard consists of a single document: the [Vocabulary Maintenance Specification](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md). That document describes the processes used to modify TDWG vocabularies and their associated documents.
-
-Contributors
-: Steve Baskauf (TDWG Vocabulary Maintenance Specification Task Group), John Wieczorek (TDWG Darwin Core Interest Group), Stan Blum (TDWG Process Interest Group), Robert A. Morris (UMASS-Boston, TDWG Imaging Interest Group), Jonathan Rees (Duke University), Joel Sachs (TDWG RDF Task Group), Greg Whitbread (TDWG Technical Architecture Group). Review manager: Dag Endresen (GBIF Norway/NHM University of Oslo)
-
-Creator
-: Vocabulary Maintenance Specification Task Group, [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+: The TDWG Vocabulary Maintenance Standard consists of a single document: the Vocabulary Maintenance Specification (http://rs.tdwg.org/vms/doc/specification/ )and their associated documents.
 
 Bibliographic citation
-: > Vocabulary Maintenance Specification Task Group (2017) Vocabulary Maintenance Standard (Endresen D, review manager). Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/642>
+: > Vocabulary Maintenance Specification Task Group. 2017. Vocabulary Maintenance Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/642
 
 ## Introduction
 
@@ -47,10 +44,24 @@ This standard is intended for those who are involved in making changes to TDWG v
 
 ## Parts of the standard
 
-The TDWG Vocabulary Maintenance Standard is described by a single document, the Vocabulary Maintenance Specification.
+This standard is comprised of one document. 
 
-- It is viewable in human-readable form at:
-<https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md>
-- It is available in Markdown format at: <https://raw.githubusercontent.com/tdwg/vocab/master/vms/maintenance-specification.md>
-- Its machine-readable metadata are available in RDF/Turtle serialization at:
-<https://raw.githubusercontent.com/tdwg/vocab/master/vms/maintenance-specification.ttl>
+Documents:
+
+**Title:** Vocabulary Maintenance Specification \
+**Permanent IRI:** [http://rs.tdwg.org/vms/doc/specification/](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md) \
+**Created:** 2017-04-25 \
+**Last modified:** 2017-04-25 \
+**Contributors:** \
+Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group \
+John Wieczorek (author) - TDWG Darwin Core Task Group \
+Stanley Blum (author) - TDWG Process Interest Group \
+Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group \
+Jonathan Rees (author) - Duke University \
+Joel Sachs (author) - TDWG RDF Task Group \
+Greg Whitbread (author) - TDWG Technical Architecture Group \
+Dag Endresen (review manager) - GBIF Norway/NHM University of Oslo \
+**Publisher:** Biodiversity Information Standards (TDWG) \
+**Abstract:** This document describes the processes used to modify TDWG vocabularies and their associated documents. \
+**Citation:** Vocabulary Maintenance Specification Task Group. 2017. Vocabulary Maintenance Specification. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/vms/doc/specification/
+

--- a/content/pages/standards/wgsrpd/index.md
+++ b/content/pages/standards/wgsrpd/index.md
@@ -8,32 +8,48 @@ tags: prior standard, 1992
 github: https://github.com/tdwg/wgsrpd
 ---
 
-<div class="alert alert-info">
-    This standard is now currated by the <a href="https://www.tdwg.org/community/geoschemes/">Geographical Schemes Interest Group</a> . 
-</div>
-
 ## Header section
 
 Title
 : World Geographical Scheme for Recording Plant Distributions (WGSRPD)
 
-Date created
-: 1992-10-01
+Permanent IRI (for citations and links)
+: <http://www.tdwg.org/standards/109>
+
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
+
+Ratified
+: 1992
 
 Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
-: <http://www.tdwg.org/standards/109>
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
 
 Abstract
 : In setting out to establish standards for data fields in botanical databases, the International Working Group on Taxonomic Databases for Plant Sciences (TDWG) identified at an early stage of its existence a need for an agreed system of geographical units at approximately "country" level and upwards for use in recording plant distributions. This would aim to provide a standard which different organisations maintaining databases could adopt so that they could compare and exchange data with each other without loss of information due to incompatible geographical boundaries. The present publication has resulted from the deliberations over a period of three years of a committee of both taxonomic and applied botanists set up to produce such a standard. The system offered covers the whole world and identifies units at four levels, firstly continental, secondly regional (or subcontinental), thirdly at what may be called "Botanical Country" level (which may often ignore purely political considerations), and fourthly at a slightly lower level called "Basic Recording Units" where political integrity is fully recognised. In many cases, where Botanical Countries have no complicating political factors, the units at Level-3 and Level-4 are identical. Very large countries, however, have been subdivided into more conveniently sized units according to constituent states or provinces. It is a fundamental principle that units at all levels are bounded either by political boundaries which appear on modern maps or by coast lines. Modern geographical information systems have not superseded the need for such a scheme. This publication provides an introduction to the system followed by an account of the rationale behind decisions and the problems that had to be considered in its design. The geographical standard itself is presented in five tables. A gazetteer is included which relates over 2100 geographical names to this system. Finally, the units recognised are shown in seventeen maps.
 
-Creator
-: 
-
 Bibliographic citation
-: > Brummitt RK (2001) World Geographical Scheme for Recording Plant Distributions, Edition 2. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/109>
+: > TDWG World Geographic Scheme for Recording Plant Distributions Committee. 2001. World Geographic Scheme for Recording Plant Distributions Standard. Biodiversity Information Standards (TDWG) http://www.tdwg.org/standards/109
+
+## Maintenance group  
+WGSRPD is now curated by the [Geographical Schemes Interest Group](https://www.tdwg.org/community/geoschemes/)
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** World Geographic Scheme for Recording Plant Distributions \
+**Permanent IRI:** [http://rs.tdwg.org/wgsrpd/doc/data/](https://github.com/tdwg/wgsrpd/blob/master/109-488-1-ED/2nd%20Edition/TDWG_geo2.pdf) \
+**Created:** 2001-08 \
+**Last modified:** 2001-08 \
+**Contributors:** \
+Richard K. Brummitt (author) \
+Francisco Pando (author) \
+S. Hollis (author) \
+Neil A. Brummitt (author) \
+**Publisher:** Hunt Institute for Botanical Documentation \
+**Abstract:** This document defines a schem for recording geographical units.  The system offered covers the whole world and identifies units at four levels, firstly continental, secondly regional (or subcontinental), thirdly at what may be called “Botanical Country” level (which may often ignore purely political considerations), and fourthly at a slightly lower level called “Basic Recording Units” where political integrity is fully recognised. \
+**Citation:** R. K. Brummitt. 2001. World Geographic Scheme for Recording Plant Distributions, Edition 2. Hunt Institute for Botanical Documentation, Carnegie Mellon University (Pittsburgh). http://rs.tdwg.org/wgsrpd/doc/data/
+

--- a/content/pages/standards/xdf/index.md
+++ b/content/pages/standards/xdf/index.md
@@ -1,36 +1,47 @@
 ---
-title: Language for the Definition and Exchange of Biological Data Sets (XDF)
-summary: 
-cover_image: 
-cover_image_by: 
-cover_image_ref: 
+title: XDF - A Language for the Definition and Exchange of Biological Data Sets
 tags: prior standard, 1991
 github: https://github.com/tdwg/prior-standards/tree/master/xdf
-status: hidden
 ---
 
 ## Header section
 
 Title
-: A Language for the Definition and Exchange of Biological Data Sets (XDF)
+: XDF - A Language for the Definition and Exchange of Biological Data Sets
 
-Date created
-: 1991-10-01
-
-Status
-: Prior standard
-
-Category
-: 
-
-Permanent IRI
+Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/108>
 
-Abstract
-: 
+Publisher
+: [Biodiversity Information Standards (TDWG)](https://www.tdwg.org/)
 
-Creator
-: 
+Ratified
+: 1991
+
+Status
+: [Prior standard](https://www.tdwg.org/standards/status-and-categories/)
+
+Abstract
+: A database file exchange medium to handle diverse classes of biological data required for file transfers between different database projects
 
 Bibliographic citation
-: 
+: > TDWG XDF Subgroup. 1992. Exchange Data Format (XDF) Standard. IUBS Commission for Plant Taxonomic Databases (TDWG) http://www.tdwg.org/standards/108
+
+## Parts of the standard
+
+This standard is comprised of one document. 
+
+Documents:
+
+**Title:** XDF: A Language for the Definition and Exchange of Biological Data Sets \
+**Permanent IRI:** [http://rs.tdwg.org/xdf/doc/article/](https://doi.org/10.1016/0895-7177(92)90163-F) \
+**Created:** 1992 \
+**Last modified:** 1992 \
+**Contributors:** \
+Richard J. White (author) \
+Robert Allkin (author) \
+**Publisher:** IUBS Commission for Plant Taxonomic Databases (TDWG) \
+**Abstract:** XDF (the Exchange Data Format) is a database file exchange medium to handle diverse classes of biological data required for file transfers between different database projects. Data sets prepared in XDF consists of text files that are effectively independent of any particular project. XDF is a high-level language for describing biological data, with its own syntax and command vocabulary, analogous to the high-level programming languages used to describe software algorithms.  \
+**Note:** Note: the article linked to the access uri does not seem to be the actual standard itself.  See reference number 16 in the article. \
+**Citation:** TDWG XDF Subgroup (Authors: R. J. White and R. Allkin). 1992. XDF: A Language for the Definition and Exchange of Biological Data Sets. IUBS Commission for Plant Taxonomic Databases (TDWG). http://rs.tdwg.org/xdf/doc/article/
+


### PR DESCRIPTION
**Please note: creating this pull request is NOT a request to merge (yet).** When all of the myriad related issues have been checked and relevant people have signed off, it can be merged. 

Interested parties: @timrobertson100 @stanblum @peterdesmet @nickynicolson @jmacklin and probably others.

This pull request is intended to deal with the following problems:

1. Standards have been conflated with standards documents. In some cases a standard has only a single document, but in many cases, standards have multiple documents, often with different authors. The SDS requires in [Section 3.1.7](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md#31-landing-page-for-the-standard) that the standards landing page list and link all parts of the standard.
2. Some of the older TDWG standards did not have any landing page or had pages with a lot of missing information (such as where to find a copy of the standard). 
3. The metadata on the standards landing page needs to agree with the machine-readable metadata that is available for standards and documents. The solution to this is to build the landing pages from the same CSV tables in the [rs.tdwg.org repo](https://github.com/tdwg/rs.tdwg.org) that is the source of the machine-readable metadata. 
4. The headers on the existing pages don't entirely conform to Section 3.1

I have used a [Python script](https://github.com/tdwg/rs.tdwg.org/blob/master/html/stds-pages/build.py) that draws from the rs.tdwg.org repo and from a [page info CSV](https://github.com/tdwg/rs.tdwg.org/blob/master/html/stds-pages/pageInfo.csv) that contains information from existing landing pages (images, headers, extra text, etc.). The script generates the draft pages in an [output directory](https://github.com/tdwg/rs.tdwg.org/tree/master/html/stds-pages/output) that mirrors the structure of the [standards pages directory in the website repo](https://github.com/tdwg/website/tree/master/content/pages/standards). After generating the drafts, they can be copied over to the corresponding website directory to replace the existing page. 

This pull request addresses some of the checkboxes in https://github.com/tdwg/infrastructure/issues/93#issue-576097169, and should close https://github.com/tdwg/website/issues/129, https://github.com/tdwg/website/issues/125, https://github.com/tdwg/website/issues/126, https://github.com/tdwg/website/issues/124, https://github.com/tdwg/website/issues/123, https://github.com/tdwg/website/issues/121, and https://github.com/tdwg/website/issues/46.

There are also some issues in the rs.tdwg.org tracker that will be addressed here. They are grouped in https://github.com/tdwg/rs.tdwg.org/milestone/1. Since these issues are generally complex, I'll address them in separate comments.

There are a number of the previously hidden stub pages that aren't fancied up with background images. Personally I don't care about that, but in the interest of maintaining a consistent look for the site, we probably should add some. **Who picks those out?** If we want to add some, it would be better/easier to just put them into the [page info CSV](https://github.com/tdwg/rs.tdwg.org/blob/master/html/stds-pages/pageInfo.csv) rather than hand editing. It takes about 0.1 second to rerun the script that builds the pages. 

I put a lot of effort into trying to figure out what documents actually need to be part of the older standards and also into figuring out who the authors were. I have undoubtedly made mistakes that will need to be fixed. Again, it is better to fix the info in the source tables in rs.tdwg.org than to do manual page editing -- that is important because manually editing the page won't have any effect on the machine-readable data. If you find errors, let me know and I can fix the sources and run them through the pipeline again.