### PR TITLE
replace backslash newlines with explicit <br/> tags

### DIFF
--- a/content/pages/standards/abcd/index.md
+++ b/content/pages/standards/abcd/index.md
@@ -42,30 +42,30 @@ This standard is comprised of 2 documents.
 
 Documents:
 
-**Title:** Access to Biological Collection Data (ABCD) Primer \
-**Permanent IRI:** [http://rs.tdwg.org/abcd/doc/primer/](https://github.com/tdwg/wiki-archive/blob/master/twiki/data/ABCD/AbcdPrimer.txt) \
-**Created:** 2006-07-27 \
-**Last modified:** 2006-07-27 \
-**Contributors:** \
-Neil Thomson (author) - Natural History Museum, London \
-Markus Döring (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
-Javier de la Torre (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-Walter G. Berendsohn (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-Wouter Addink (author) - Expertise Centre for Taxonomic Identification, Amsterdam  \
-William Ulate  (author) - INBioparque, Santo Domingo de Heredia  \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This primer is intended to provide an easily readable background to ABCD and should take anyone with no knowledge of the standard to the very point where they would be able to understand the principles and the more detailed technical specification. Examples are given which are complemented by references to the normative texts. \
+**Title:** Access to Biological Collection Data (ABCD) Primer <br/>
+**Permanent IRI:** [http://rs.tdwg.org/abcd/doc/primer/](https://github.com/tdwg/wiki-archive/blob/master/twiki/data/ABCD/AbcdPrimer.txt) <br/>
+**Created:** 2006-07-27 <br/>
+**Last modified:** 2006-07-27 <br/>
+**Contributors:** <br/>
+Neil Thomson (author) - Natural History Museum, London <br/>
+Markus Döring (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental <br/>
+Javier de la Torre (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+Walter G. Berendsohn (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+Wouter Addink (author) - Expertise Centre for Taxonomic Identification, Amsterdam  <br/>
+William Ulate  (author) - INBioparque, Santo Domingo de Heredia  <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This primer is intended to provide an easily readable background to ABCD and should take anyone with no knowledge of the standard to the very point where they would be able to understand the principles and the more detailed technical specification. Examples are given which are complemented by references to the normative texts. <br/>
 **Citation:** TDWG Access to Biological Collections Data (ABCD) Task Group 2006. Access to Biological Collections Data (ABCD) Primer. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/abcd/doc/primer/
 
-**Title:** Access to Biological Collection Data (ABCD) XML Schema \
-**Permanent IRI:** [http://rs.tdwg.org/abcd/doc/xmlschema/](http://rs.tdwg.org/abcd/2.06/ABCD_2.06.xsd) \
-**Created:** 2007-06-13 \
-**Last modified:** 2007-06-13 \
-**Contributors:** \
-Walter G. Berendsohn (lead author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** XML schema document for the Access to Biological Collection Data standard. \
-**Note:** See also https://raw.githack.com/tdwg/abcd/master/2.06/rddl-2007-10-18.html \
+**Title:** Access to Biological Collection Data (ABCD) XML Schema <br/>
+**Permanent IRI:** [http://rs.tdwg.org/abcd/doc/xmlschema/](http://rs.tdwg.org/abcd/2.06/ABCD_2.06.xsd) <br/>
+**Created:** 2007-06-13 <br/>
+**Last modified:** 2007-06-13 <br/>
+**Contributors:** <br/>
+Walter G. Berendsohn (lead author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** XML schema document for the Access to Biological Collection Data standard. <br/>
+**Note:** See also https://raw.githack.com/tdwg/abcd/master/2.06/rddl-2007-10-18.html <br/>
 **Citation:** TDWG Access to Biological Collections Data (ABCD) Task Group 2007. Access to Biological Collections Data (ABCD) XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/abcd/doc/xmlschema/
 

--- a/content/pages/standards/ac/index.md
+++ b/content/pages/standards/ac/index.md
@@ -57,124 +57,124 @@ subtype controlled vocabulary (<http://rs.tdwg.org/acsubtype/>)
 
 Documents:
 
-**Title:** Audubon Core Term List \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/termlist/](https://tdwg.github.io/ac/termlist/) \
-**Created:** 2013-10-23 \
-**Last modified:** 2021-02-01 \
-**Contributors:** \
-Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
-Vijay Barve (author) \
-Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
-Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
-José Cuadra (author) \
-Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
-Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
-Patrick Leary (author) \
-Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
-Annette Olson (author) - American Association for the Advancement of Science \
-Greg Riccardi (author) - Florida State University, Tallahassee, USA \
-Ivan Teage (author) \
-Steve Baskauf (author) - Audubon Core Maintenance Group \
-Dan Stowell (author) - Queen Mary University of London \
-Edward Baker (author) - Natural History Museum, London \
-Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. It aims to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains a list of attributes of each Audubon Core term, including a documentation name, a specified URI, a recommended English label for user interfaces, a definition, and some ancillary notes. The version shown here was adopted by Biodiversity Information Standards / TDWG at the general meeting in October 2013 and updated in 2021. This document contains normative content that may not be changed without due process. \
+**Title:** Audubon Core Term List <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/termlist/](https://tdwg.github.io/ac/termlist/) <br/>
+**Created:** 2013-10-23 <br/>
+**Last modified:** 2021-02-01 <br/>
+**Contributors:** <br/>
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Vijay Barve (author) <br/>
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark <br/>
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+José Cuadra (author) <br/>
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA <br/>
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
+Patrick Leary (author) <br/>
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
+Annette Olson (author) - American Association for the Advancement of Science <br/>
+Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
+Ivan Teage (author) <br/>
+Steve Baskauf (author) - Audubon Core Maintenance Group <br/>
+Dan Stowell (author) - Queen Mary University of London <br/>
+Edward Baker (author) - Natural History Museum, London <br/>
+Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. It aims to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains a list of attributes of each Audubon Core term, including a documentation name, a specified URI, a recommended English label for user interfaces, a definition, and some ancillary notes. The version shown here was adopted by Biodiversity Information Standards / TDWG at the general meeting in October 2013 and updated in 2021. This document contains normative content that may not be changed without due process. <br/>
 **Citation:** Audubon Core Maintenance Group. 2021. Audubon Core Term List. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/termlist/2021-02-01
 
-**Title:** Audubon Core Structure \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/structure/](https://tdwg.github.io/ac/structure/) \
-**Created:** 2013-10-23 \
-**Last modified:** 2020-01-27 \
-**Contributors:** \
-Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
-Vijay Barve (author) \
-Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
-Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
-José Cuadra (author) \
-Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
-Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
-Patrick Leary (author) \
-Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
-Annette Olson (author) - American Association for the Advancement of Science \
-Greg Riccardi (author) - Florida State University, Tallahassee, USA \
-Ivan Teage (author) \
-Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains material introductory to the Audubon Core Term List. \
+**Title:** Audubon Core Structure <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/structure/](https://tdwg.github.io/ac/structure/) <br/>
+**Created:** 2013-10-23 <br/>
+**Last modified:** 2020-01-27 <br/>
+**Contributors:** <br/>
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Vijay Barve (author) <br/>
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark <br/>
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+José Cuadra (author) <br/>
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA <br/>
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
+Patrick Leary (author) <br/>
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
+Annette Olson (author) - American Association for the Advancement of Science <br/>
+Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
+Ivan Teage (author) <br/>
+Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains material introductory to the Audubon Core Term List. <br/>
 **Citation:** Multimedia Resources Task Group. 2013. Audubon Core Structure. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/structure/
 
-**Title:** Audubon Core Introduction \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/introduction/](https://tdwg.github.io/ac/introduction/) \
-**Created:** 2013-10-23 \
-**Last modified:** 2013-10-23 \
-**Contributors:** \
-Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
-Vijay Barve (author) \
-Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
-Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
-José Cuadra (author) \
-Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
-Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
-Patrick Leary (author) \
-Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
-Annette Olson (author) - American Association for the Advancement of Science \
-Greg Riccardi (author) - Florida State University, Tallahassee, USA \
-Ivan Teage (author) \
-Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.  \
+**Title:** Audubon Core Introduction <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/introduction/](https://tdwg.github.io/ac/introduction/) <br/>
+**Created:** 2013-10-23 <br/>
+**Last modified:** 2013-10-23 <br/>
+**Contributors:** <br/>
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Vijay Barve (author) <br/>
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark <br/>
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+José Cuadra (author) <br/>
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA <br/>
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
+Patrick Leary (author) <br/>
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
+Annette Olson (author) - American Association for the Advancement of Science <br/>
+Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
+Ivan Teage (author) <br/>
+Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.  <br/>
 **Citation:** Multimedia Resources Task Group. 2013. Audubon Core Introduction. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/introduction/
 
-**Title:** Audubon Core Guide \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/guide/](https://tdwg.github.io/ac/guide/) \
-**Created:** 2013-10-15 \
-**Last modified:** 2013-10-15 \
-**Contributors:** \
-Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark \
-Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
-Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA \
-Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany \
-Robert A. Morris (lead author) - University of Massachusetts at Boston, USA \
-Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA \
-Annette Olson (author) - American Association for the Advancement of Science \
-Greg Riccardi (author) - Florida State University, Tallahassee, USA \
-Éamonn Ó Tuama (author) - Global Biodiversity Information Facility, Copenhagen, Denmark \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. This non-normative document provides some background to the aims and uses of the standard. \
+**Title:** Audubon Core Guide <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/guide/](https://tdwg.github.io/ac/guide/) <br/>
+**Created:** 2013-10-15 <br/>
+**Last modified:** 2013-10-15 <br/>
+**Contributors:** <br/>
+Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark <br/>
+Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA <br/>
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
+Annette Olson (author) - American Association for the Advancement of Science <br/>
+Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
+Éamonn Ó Tuama (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. This non-normative document provides some background to the aims and uses of the standard. <br/>
 **Citation:** Multimedia Resources Task Group. 2013. Audubon Core Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/guide/
 
-**Title:** Controlled Vocabulary for Dublin Core format: List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/format/](https://tdwg.github.io/ac/format/) \
-**Created:** 2020-10-13 \
-**Last modified:** 2020-10-13 \
-**Contributors:** \
-Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries \
-Matthew Blissett (contributor) - Global Biodiversity Information Facility \
-Douglas Boyer (contributor) - Duke University \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** Audubon Core borrows the Dublin Core terms dc:format and dcterms:format to provide information about the physical or electronic format of a media item. This controlled vocabulary provides values for those two terms. \
+**Title:** Controlled Vocabulary for Dublin Core format: List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/format/](https://tdwg.github.io/ac/format/) <br/>
+**Created:** 2020-10-13 <br/>
+**Last modified:** 2020-10-13 <br/>
+**Contributors:** <br/>
+Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries <br/>
+Matthew Blissett (contributor) - Global Biodiversity Information Facility <br/>
+Douglas Boyer (contributor) - Duke University <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** Audubon Core borrows the Dublin Core terms dc:format and dcterms:format to provide information about the physical or electronic format of a media item. This controlled vocabulary provides values for those two terms. <br/>
 **Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Dublin Core format: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/format/2020-10-13
 
-**Title:** Controlled Vocabulary for Audubon Core subtype: List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/subtype/](https://tdwg.github.io/ac/subtype/) \
-**Created:** 2020-10-13 \
-**Last modified:** 2020-10-13 \
-**Contributors:** \
-Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** Audubon Core uses the terms ac:subtype and ac:subtypeLiteral to refine the type of a media item to a level more specific than the Dublin Core Type Vocabulary, http://purl.org/dc/dcmitype/. This controlled vocabulary provides values for ac:subtype and ac:subtypeLiteral. \
+**Title:** Controlled Vocabulary for Audubon Core subtype: List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/subtype/](https://tdwg.github.io/ac/subtype/) <br/>
+**Created:** 2020-10-13 <br/>
+**Last modified:** 2020-10-13 <br/>
+**Contributors:** <br/>
+Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** Audubon Core uses the terms ac:subtype and ac:subtypeLiteral to refine the type of a media item to a level more specific than the Dublin Core Type Vocabulary, http://purl.org/dc/dcmitype/. This controlled vocabulary provides values for ac:subtype and ac:subtypeLiteral. <br/>
 **Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core subtype: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/subtype/2020-10-13
 
-**Title:** Controlled Vocabulary for Audubon Core variant: List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/ac/doc/variant/](https://tdwg.github.io/ac/variant/) \
-**Created:** 2020-10-13 \
-**Last modified:** 2020-10-13 \
-**Contributors:** \
-Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries \
-Dan Stowell (contributor) - Queen Mary University of London \
-Edward Baker (contributor) - Natural History Museum, London \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** Audubon Core uses the terms ac:variant and ac:variantLiteral to provide information about the size, extent, and availability of the Service Access Point of a media item. This controlled vocabulary provides values for those terms. \
+**Title:** Controlled Vocabulary for Audubon Core variant: List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ac/doc/variant/](https://tdwg.github.io/ac/variant/) <br/>
+**Created:** 2020-10-13 <br/>
+**Last modified:** 2020-10-13 <br/>
+**Contributors:** <br/>
+Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries <br/>
+Dan Stowell (contributor) - Queen Mary University of London <br/>
+Edward Baker (contributor) - Natural History Museum, London <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** Audubon Core uses the terms ac:variant and ac:variantLiteral to provide information about the size, extent, and availability of the Service Access Point of a media item. This controlled vocabulary provides values for those terms. <br/>
 **Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core variant: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/variant/2020-10-13
 

--- a/content/pages/standards/bph-supplementum/index.md
+++ b/content/pages/standards/bph-supplementum/index.md
@@ -33,15 +33,15 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum \
-**Permanent IRI:** [http://rs.tdwg.org/bphsup/doc/book/](http://huntbotanical.org/publications/show.php?=92) \
-**Created:** 1991 \
-**Last modified:** 1991 \
-**Contributors:** \
-Gavin D. R. Bridson (author) \
-Elizabeth R. Smith (author) \
-**Publisher:** Hunt Institute for Botanical Documentation \
-**Abstract:** A supplement to and partial revision of B-P-H (1968), B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum (1991) contains over 25,000 title entries arranged alphabetically by title and is designed as a key to entries in both volumes. It features citation abbreviations for all titles, improved cross-referencing and an expanded thesaurus of title words and their abbreviation equivalents. The supplement includes periodicals dealing with biotechnology, molecular biology, environmental studies and conservation.  \
-**Note:** Available only in print and is out of print. See http://huntbotanical.org/publications/show.php?=92. Contained additional entries and was a key to entries in it and in the first edition of B-P-H. \
+**Title:** B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum <br/>
+**Permanent IRI:** [http://rs.tdwg.org/bphsup/doc/book/](http://huntbotanical.org/publications/show.php?=92) <br/>
+**Created:** 1991 <br/>
+**Last modified:** 1991 <br/>
+**Contributors:** <br/>
+Gavin D. R. Bridson (author) <br/>
+Elizabeth R. Smith (author) <br/>
+**Publisher:** Hunt Institute for Botanical Documentation <br/>
+**Abstract:** A supplement to and partial revision of B-P-H (1968), B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum (1991) contains over 25,000 title entries arranged alphabetically by title and is designed as a key to entries in both volumes. It features citation abbreviations for all titles, improved cross-referencing and an expanded thesaurus of title words and their abbreviation equivalents. The supplement includes periodicals dealing with biotechnology, molecular biology, environmental studies and conservation.  <br/>
+**Note:** Available only in print and is out of print. See http://huntbotanical.org/publications/show.php?=92. Contained additional entries and was a key to entries in it and in the first edition of B-P-H. <br/>
 **Citation:** Bridson, G. D. R. and E. R. Smith. 1991. B-P-H/S: Botanico-Periodicum-Huntianum/Supplementum. Hunt Institute for Botanical Documentation, Carnegie Mellon University (Pittsburgh). ISBN: 0913196541. http://rs.tdwg.org/bphsup/doc/book/
 

--- a/content/pages/standards/bph/index.md
+++ b/content/pages/standards/bph/index.md
@@ -33,14 +33,14 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** B-P-H-2: Periodicals with Botanical content (edition 2) \
-**Permanent IRI:** [http://rs.tdwg.org/bph/doc/book/](http://huntbotanical.org/publications/show.php?=92) \
-**Created:** 1968 \
-**Last modified:** 2004 \
-**Contributors:** \
-Gavin D. R. Bridson (author) - Hunt Institute \
-**Publisher:** Hunt Institute for Botanical Documentation \
-**Abstract:** This edition includes the abbreviations for titles of books. \
-**Note:** The second edition includes material in both the first edition of B-H-P and the 1991 B-P-H/S supplement.  The print version is out of print.  See http://huntbotanical.org/publications/show.php?=92. The online database is at http://huntbotanical.org/databases/show.php?1 \
+**Title:** B-P-H-2: Periodicals with Botanical content (edition 2) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/bph/doc/book/](http://huntbotanical.org/publications/show.php?=92) <br/>
+**Created:** 1968 <br/>
+**Last modified:** 2004 <br/>
+**Contributors:** <br/>
+Gavin D. R. Bridson (author) - Hunt Institute <br/>
+**Publisher:** Hunt Institute for Botanical Documentation <br/>
+**Abstract:** This edition includes the abbreviations for titles of books. <br/>
+**Note:** The second edition includes material in both the first edition of B-H-P and the 1991 B-P-H/S supplement.  The print version is out of print.  See http://huntbotanical.org/publications/show.php?=92. The online database is at http://huntbotanical.org/databases/show.php?1 <br/>
 **Citation:** Bridson, G. D. R. 2004. B-P-H-2: Periodicals with Botanical content (edition 2). Hunt Institute for Botanical Documentation, Carnegie Mellon University (Pittsburgh). ISBN: 0913196789. http://rs.tdwg.org/bph/doc/book/
 

--- a/content/pages/standards/delta/index.md
+++ b/content/pages/standards/delta/index.md
@@ -42,15 +42,15 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Definition of the Delta Format \
-**Permanent IRI:** [http://rs.tdwg.org/delta/doc/definition/](https://github.com/tdwg/delta/blob/master/107-516-1-ED.pdf) \
-**Created:** 2005-09-13 \
-**Last modified:** 2005-09-13 \
-**Contributors:** \
-Michael J. Dallwitz (author) \
-Toni Anne Paine (author) \
-**Publisher:** Commonwealth Scientific and Industrial Research Organisation (CSIRO) \
-**Abstract:** This document is primarily for the benefit of programmers, and contains more detail than would usually be required by users of the DELTA format. It provides an introduction to the format, and details necessary to encode data in the format. \
-**Note:** See http://delta-intkey.com/www/overview.htm for an overview and http://delta-intkey.com/www/use.htm for conditions of use. \
+**Title:** Definition of the Delta Format <br/>
+**Permanent IRI:** [http://rs.tdwg.org/delta/doc/definition/](https://github.com/tdwg/delta/blob/master/107-516-1-ED.pdf) <br/>
+**Created:** 2005-09-13 <br/>
+**Last modified:** 2005-09-13 <br/>
+**Contributors:** <br/>
+Michael J. Dallwitz (author) <br/>
+Toni Anne Paine (author) <br/>
+**Publisher:** Commonwealth Scientific and Industrial Research Organisation (CSIRO) <br/>
+**Abstract:** This document is primarily for the benefit of programmers, and contains more detail than would usually be required by users of the DELTA format. It provides an introduction to the format, and details necessary to encode data in the format. <br/>
+**Note:** See http://delta-intkey.com/www/overview.htm for an overview and http://delta-intkey.com/www/use.htm for conditions of use. <br/>
 **Citation:** Dallwitz, M. J. and T. A. Paine. 1999 onwards. Definition of the Delta Format. Version: 2005-09-13. http://delta-intkey.com/
 

--- a/content/pages/standards/dwc/index.md
+++ b/content/pages/standards/dwc/index.md
@@ -92,193 +92,193 @@ Darwin Core Chronometric Age Extension vocabulary (<http://rs.tdwg.org/chrono/>)
 
 Documents:
 
-**Title:** Darwin Core RDF Guide \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/rdf/](https://dwc.tdwg.org/rdf/) \
-**Created:** 2015-06-02 \
-**Last modified:** 2015-06-02 \
-**Contributors:** \
-Steve Baskauf (lead author) - TDWG RDF/OWL Task Group \
-John Wieczorek (author) - TDWG Darwin Core Task Group \
-John Deck  (author) - Genomic Biodiversity Working Group \
-Campbell Webb  (author) - TDWG RDF/OWL Task Group \
-Paul J. Morris  (author) - Harvard University Herbaria/Museum of Comparative Zoölogy \
-Mark Schildhauer  (author) - National Center for Ecological Analysis and Synthesis \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This guide is intended to facilitate the use of Darwin Core terms in the Resource Description Framework (RDF). It explains basic features of RDF and provides details of how to expose data in the form of RDF using Darwin Core terms and terms from other key vocabularies. It defines terms in the namespace http://rs.tdwg.org/dwc/iri/ which are intended for use excusively with non-literal objects.  \
+**Title:** Darwin Core RDF Guide <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/rdf/](https://dwc.tdwg.org/rdf/) <br/>
+**Created:** 2015-06-02 <br/>
+**Last modified:** 2015-06-02 <br/>
+**Contributors:** <br/>
+Steve Baskauf (lead author) - TDWG RDF/OWL Task Group <br/>
+John Wieczorek (author) - TDWG Darwin Core Task Group <br/>
+John Deck  (author) - Genomic Biodiversity Working Group <br/>
+Campbell Webb  (author) - TDWG RDF/OWL Task Group <br/>
+Paul J. Morris  (author) - Harvard University Herbaria/Museum of Comparative Zoölogy <br/>
+Mark Schildhauer  (author) - National Center for Ecological Analysis and Synthesis <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This guide is intended to facilitate the use of Darwin Core terms in the Resource Description Framework (RDF). It explains basic features of RDF and provides details of how to expose data in the form of RDF using Darwin Core terms and terms from other key vocabularies. It defines terms in the namespace http://rs.tdwg.org/dwc/iri/ which are intended for use excusively with non-literal objects.  <br/>
 **Citation:** Darwin Core and RDF/OWL Task Groups. 2015. Darwin Core RDF Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/guides/rdf/
 
-**Title:** Darwin Core Text Guide \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/text/](https://dwc.tdwg.org/text/) \
-**Created:** 2014-11-08 \
-**Last modified:** 2014-11-08 \
-**Contributors:** \
-Tim Robertson (lead author) - Global Biodiversity Information Facility \
-Markus Döring (author) - Global Biodiversity Information Facility \
-John Wieczorek (author) - TDWG Darwin Core Task Group \
-Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
-Dave Vieglais (author) - KU Natural History Museum \
-Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document provides guidelines for implementing Darwin Core in Text files. \
+**Title:** Darwin Core Text Guide <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/text/](https://dwc.tdwg.org/text/) <br/>
+**Created:** 2014-11-08 <br/>
+**Last modified:** 2014-11-08 <br/>
+**Contributors:** <br/>
+Tim Robertson (lead author) - Global Biodiversity Information Facility <br/>
+Markus Döring (author) - Global Biodiversity Information Facility <br/>
+John Wieczorek (author) - TDWG Darwin Core Task Group <br/>
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental <br/>
+Dave Vieglais (author) - KU Natural History Museum <br/>
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document provides guidelines for implementing Darwin Core in Text files. <br/>
 **Citation:** Darwin Core Task Group. 2014. Darwin Core Text Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/guides/text/
 
-**Title:** Darwin Core XML Guide \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/xml/](https://dwc.tdwg.org/xml/) \
-**Created:** 2014-11-08 \
-**Last modified:** 2014-11-08 \
-**Contributors:** \
-John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley \
-Markus Döring (author) - Global Biodiversity Information Facility \
-Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
-Tim Robertson (author) - Global Biodiversity Information Facility \
-Dave Vieglais (author) - KU Natural History Museum \
-Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document provides guidelines for the implementation of Darwin Core in XML. \
+**Title:** Darwin Core XML Guide <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/xml/](https://dwc.tdwg.org/xml/) <br/>
+**Created:** 2014-11-08 <br/>
+**Last modified:** 2014-11-08 <br/>
+**Contributors:** <br/>
+John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley <br/>
+Markus Döring (author) - Global Biodiversity Information Facility <br/>
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental <br/>
+Tim Robertson (author) - Global Biodiversity Information Facility <br/>
+Dave Vieglais (author) - KU Natural History Museum <br/>
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document provides guidelines for the implementation of Darwin Core in XML. <br/>
 **Citation:** Darwin Core Task Group. 2014. Darwin Core XML Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/guides/xml/
 
-**Title:** Simple Darwin Core \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/simple/](https://dwc.tdwg.org/simple/) \
-**Created:** 2014-11-08 \
-**Last modified:** 2014-11-08 \
-**Contributors:** \
-John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley \
-Markus Döring (author) - Global Biodiversity Information Facility \
-Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
-Tim Robertson (author) - Global Biodiversity Information Facility \
-Dave Vieglais (author) - KU Natural History Museum \
-Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document is a reference for the Simple Darwin Core standard, a mechanism used to share biodiversity information using the simplest methods and structure.   \
+**Title:** Simple Darwin Core <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/simple/](https://dwc.tdwg.org/simple/) <br/>
+**Created:** 2014-11-08 <br/>
+**Last modified:** 2014-11-08 <br/>
+**Contributors:** <br/>
+John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley <br/>
+Markus Döring (author) - Global Biodiversity Information Facility <br/>
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental <br/>
+Tim Robertson (author) - Global Biodiversity Information Facility <br/>
+Dave Vieglais (author) - KU Natural History Museum <br/>
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document is a reference for the Simple Darwin Core standard, a mechanism used to share biodiversity information using the simplest methods and structure.   <br/>
 **Citation:** Darwin Core Task Group. 2014. Simple Darwin Core. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/simple/
 
-**Title:** Darwin Core Namespace Policy \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/namespace/](https://dwc.tdwg.org/namespace/) \
-**Created:** 2014-11-08 \
-**Last modified:** 2014-11-08 \
-**Contributors:** \
-John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley \
-Markus Döring (author) - Global Biodiversity Information Facility \
-Renato De Giovanni (author) - Centro de Referência em Informação Ambiental \
-Tim Robertson (author) - Global Biodiversity Information Facility \
-Dave Vieglais (author) - KU Natural History Museum \
-Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** All terms in the Darwin Core must be assigned a unique Uniform Resource Identifier (URI). For convenience, the term URIs that are assigned and managed by the Darwin Core Task Group are grouped into collections known as Darwin Core namespaces. This document describes how term URIs are allocated by the Darwin Core Task Group and the policies associated with Darwin Core namespaces.  \
+**Title:** Darwin Core Namespace Policy <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/terms/namespace/](https://dwc.tdwg.org/namespace/) <br/>
+**Created:** 2014-11-08 <br/>
+**Last modified:** 2014-11-08 <br/>
+**Contributors:** <br/>
+John Wieczorek (lead author) - Museum of Vertebrate Zoology at Berkeley <br/>
+Markus Döring (author) - Global Biodiversity Information Facility <br/>
+Renato De Giovanni (author) - Centro de Referência em Informação Ambiental <br/>
+Tim Robertson (author) - Global Biodiversity Information Facility <br/>
+Dave Vieglais (author) - KU Natural History Museum <br/>
+Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** All terms in the Darwin Core must be assigned a unique Uniform Resource Identifier (URI). For convenience, the term URIs that are assigned and managed by the Darwin Core Task Group are grouped into collections known as Darwin Core namespaces. This document describes how term URIs are allocated by the Darwin Core Task Group and the policies associated with Darwin Core namespaces.  <br/>
 **Citation:** Darwin Core Task Group. 2014. Darwin Core Namespace Policy. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/terms/namespace/
 
-**Title:** Darwin Core List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/list/](https://dwc.tdwg.org/list/) \
-**Created:** 2020-08-12 \
-**Last modified:** 2021-07-15 \
-**Contributors:** \
-John Wieczorek (contributor) - VertNet \
-Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Steve Baskauf (contributor) - Vanderbilt University Libraries \
-Tim Robertson (contributor) - Global Biodiversity Information Facility \
-Markus Döring (contributor) - Global Biodiversity Information Facility \
-Quentin Groom (contributor) - Botanic Garden Meise \
-Stijn Van Hoey (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-David Bloom (contributor) - VertNet \
-Paula Zermoglio (contributor) - VertNet \
-Robert Guralnick (contributor) - University of Florida \
-John Deck (contributor) - Genomic Biodiversity Working Group \
-Gail Kampmeier (review manager) - Illinois Natural History Survey \
-Dave Vieglais (contributor) - KU Natural History Museum \
-Renato De Giovanni (contributor) - Centro de Referência em Informação Ambiental \
-Campbell Webb (contributor) - TDWG RDF/OWL Task Group \
-Paul J. Morris (contributor) - Harvard University Herbaria/Museum of Comparative Zoölogy \
-Mark Schildhauer (contributor) - National Center for Ecological Analysis and Synthesis \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** Darwin Core is a vocabulary standard for transmitting information about biodiversity. This document lists all terms in namespaces currently used in the vocabulary. \
+**Title:** Darwin Core List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/list/](https://dwc.tdwg.org/list/) <br/>
+**Created:** 2020-08-12 <br/>
+**Last modified:** 2021-07-15 <br/>
+**Contributors:** <br/>
+John Wieczorek (contributor) - VertNet <br/>
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Tim Robertson (contributor) - Global Biodiversity Information Facility <br/>
+Markus Döring (contributor) - Global Biodiversity Information Facility <br/>
+Quentin Groom (contributor) - Botanic Garden Meise <br/>
+Stijn Van Hoey (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+David Bloom (contributor) - VertNet <br/>
+Paula Zermoglio (contributor) - VertNet <br/>
+Robert Guralnick (contributor) - University of Florida <br/>
+John Deck (contributor) - Genomic Biodiversity Working Group <br/>
+Gail Kampmeier (review manager) - Illinois Natural History Survey <br/>
+Dave Vieglais (contributor) - KU Natural History Museum <br/>
+Renato De Giovanni (contributor) - Centro de Referência em Informação Ambiental <br/>
+Campbell Webb (contributor) - TDWG RDF/OWL Task Group <br/>
+Paul J. Morris (contributor) - Harvard University Herbaria/Museum of Comparative Zoölogy <br/>
+Mark Schildhauer (contributor) - National Center for Ecological Analysis and Synthesis <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** Darwin Core is a vocabulary standard for transmitting information about biodiversity. This document lists all terms in namespaces currently used in the vocabulary. <br/>
 **Citation:** Darwin Core Maintenance Group. 2021. List of Darwin Core terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/list/2021-07-15
 
-**Title:** Degree of Establishment Controlled Vocabulary List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/doe/](https://dwc.tdwg.org/doe/) \
-**Created:** 2020-10-13 \
-**Last modified:** 2020-10-13 \
-**Contributors:** \
-Quentin Groom (lead author) - Botanic Garden Meise \
-Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform \
-Steve Baskauf (contributor) - Vanderbilt University Libraries \
-Arthur Chapman (contributor) - Australian Biodiversity Information Services \
-Melodie McGeoch (contributor) - McGeoch Research Group \
-Ramona Walls (contributor) - University of Arizona \
-John Wieczorek (contributor) - VertNet \
-John R.U. Wilson (contributor) - South African National Biodiversity Institute \
-Paula F F Zermoglio (contributor) - VertNet \
-Annie Simpson (contributor) - U.S. Geological Survey \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Darwin Core term degreeOfEstablishment provides information about degree to which an Organism survives, reproduces, and expands its range at the given place and time.. The Degree of Establishment Controlled Vocabulary provides terms that should be used as values for dwc:degreeOfEstablishment and dwciri:degreeOfEstablishment. \
+**Title:** Degree of Establishment Controlled Vocabulary List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/doe/](https://dwc.tdwg.org/doe/) <br/>
+**Created:** 2020-10-13 <br/>
+**Last modified:** 2020-10-13 <br/>
+**Contributors:** <br/>
+Quentin Groom (lead author) - Botanic Garden Meise <br/>
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform <br/>
+Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Arthur Chapman (contributor) - Australian Biodiversity Information Services <br/>
+Melodie McGeoch (contributor) - McGeoch Research Group <br/>
+Ramona Walls (contributor) - University of Arizona <br/>
+John Wieczorek (contributor) - VertNet <br/>
+John R.U. Wilson (contributor) - South African National Biodiversity Institute <br/>
+Paula F F Zermoglio (contributor) - VertNet <br/>
+Annie Simpson (contributor) - U.S. Geological Survey <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Darwin Core term degreeOfEstablishment provides information about degree to which an Organism survives, reproduces, and expands its range at the given place and time.. The Degree of Establishment Controlled Vocabulary provides terms that should be used as values for dwc:degreeOfEstablishment and dwciri:degreeOfEstablishment. <br/>
 **Citation:** Darwin Core Maintenance Group. 2020. Degree of Establishment Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/doe/2020-10-13
 
-**Title:** Establishment Means Controlled Vocabulary List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/em/](https://dwc.tdwg.org/em/) \
-**Created:** 2020-10-13 \
-**Last modified:** 2020-10-13 \
-**Contributors:** \
-Quentin Groom (lead author) - Botanic Garden Meise \
-Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform \
-Steve Baskauf (contributor) - Vanderbilt University Libraries \
-Arthur Chapman (contributor) - Australian Biodiversity Information Services \
-Melodie McGeoch (contributor) - McGeoch Research Group \
-Ramona Walls (contributor) - University of Arizona \
-John Wieczorek (contributor) - VertNet \
-John R.U. Wilson (contributor) - South African National Biodiversity Institute \
-Paula F F Zermoglio (contributor) - VertNet \
-Annie Simpson (contributor) - U.S. Geological Survey \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Darwin Core term establishmentMeans provides information about whether an organism or organisms have been introduced to a given place and time through the direct or indirect activity of modern humans. The Establishment Means Controlled Vocabulary provides terms that should be used as values for dwc:establishmentMeans and dwciri:establishmentMeans. \
+**Title:** Establishment Means Controlled Vocabulary List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/em/](https://dwc.tdwg.org/em/) <br/>
+**Created:** 2020-10-13 <br/>
+**Last modified:** 2020-10-13 <br/>
+**Contributors:** <br/>
+Quentin Groom (lead author) - Botanic Garden Meise <br/>
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform <br/>
+Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Arthur Chapman (contributor) - Australian Biodiversity Information Services <br/>
+Melodie McGeoch (contributor) - McGeoch Research Group <br/>
+Ramona Walls (contributor) - University of Arizona <br/>
+John Wieczorek (contributor) - VertNet <br/>
+John R.U. Wilson (contributor) - South African National Biodiversity Institute <br/>
+Paula F F Zermoglio (contributor) - VertNet <br/>
+Annie Simpson (contributor) - U.S. Geological Survey <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Darwin Core term establishmentMeans provides information about whether an organism or organisms have been introduced to a given place and time through the direct or indirect activity of modern humans. The Establishment Means Controlled Vocabulary provides terms that should be used as values for dwc:establishmentMeans and dwciri:establishmentMeans. <br/>
 **Citation:** Darwin Core Maintenance Group. 2020. Establishment Means Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/em/2020-10-13
 
-**Title:** Pathway Controlled Vocabulary List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/pw/](https://dwc.tdwg.org/pw/) \
-**Created:** 2020-10-13 \
-**Last modified:** 2020-10-13 \
-**Contributors:** \
-Quentin Groom (lead author) - Botanic Garden Meise \
-Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) \
-Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform \
-Steve Baskauf (contributor) - Vanderbilt University Libraries \
-Arthur Chapman (contributor) - Australian Biodiversity Information Services \
-Melodie McGeoch (contributor) - McGeoch Research Group \
-Ramona Walls (contributor) - University of Arizona \
-John Wieczorek (contributor) - VertNet \
-John R.U. Wilson (contributor) - South African National Biodiversity Institute \
-Paula F F Zermoglio (contributor) - VertNet \
-Annie Simpson (contributor) - U.S. Geological Survey \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Darwin Core term pathway provides information about the process by which an Organism came to be in a given place at a given time. The Pathway Controlled Vocabulary provides terms that should be used as values for dwc:pathway and dwciri:pathway. \
+**Title:** Pathway Controlled Vocabulary List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/pw/](https://dwc.tdwg.org/pw/) <br/>
+**Created:** 2020-10-13 <br/>
+**Last modified:** 2020-10-13 <br/>
+**Contributors:** <br/>
+Quentin Groom (lead author) - Botanic Garden Meise <br/>
+Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
+Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform <br/>
+Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Arthur Chapman (contributor) - Australian Biodiversity Information Services <br/>
+Melodie McGeoch (contributor) - McGeoch Research Group <br/>
+Ramona Walls (contributor) - University of Arizona <br/>
+John Wieczorek (contributor) - VertNet <br/>
+John R.U. Wilson (contributor) - South African National Biodiversity Institute <br/>
+Paula F F Zermoglio (contributor) - VertNet <br/>
+Annie Simpson (contributor) - U.S. Geological Survey <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Darwin Core term pathway provides information about the process by which an Organism came to be in a given place at a given time. The Pathway Controlled Vocabulary provides terms that should be used as values for dwc:pathway and dwciri:pathway. <br/>
 **Citation:** Darwin Core Maintenance Group. 2020. Pathway Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/pw//2020-10-13
 
-**Title:** Chronometric Age Vocabulary List of Terms \
-**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/chrono/](https://tdwg.github.io/chrono/list/) \
-**Created:** 2021-04-27 \
-**Last modified:** 2021-04-27 \
-**Contributors:** \
-John Wieczorek (lead author) - VertNet \
-Laura Brenskelle (contributor) - University of Florida \
-Robert Guralnick (contributor) - University of Florida \
-Kitty Emery (contributor) - University of Florida \
-Michelle LeFebvre (contributor) - University of Florida \
-Neill Wallis (contributor) - University of Florida \
-Steve Baskauf (contributor) - Vanderbilt University Libraries \
-Marie Elise Lecoq (contributor) \
-Eric Kansa (contributor) - Harvard University \
-Sarah Kansa (contributor) - The Alexandria Archive Institute \
-Denné Reed (contributor) - University of Texas at Austin \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** The Chronometric Age Vocabulary is a standard for transmitting information about chronometric ages - the processes and results of an assay or other analysis used to determine the age of a MaterialSample. This document lists all terms in namespaces currently used in the vocabulary. \
+**Title:** Chronometric Age Vocabulary List of Terms <br/>
+**Permanent IRI:** [http://rs.tdwg.org/dwc/doc/chrono/](https://tdwg.github.io/chrono/list/) <br/>
+**Created:** 2021-04-27 <br/>
+**Last modified:** 2021-04-27 <br/>
+**Contributors:** <br/>
+John Wieczorek (lead author) - VertNet <br/>
+Laura Brenskelle (contributor) - University of Florida <br/>
+Robert Guralnick (contributor) - University of Florida <br/>
+Kitty Emery (contributor) - University of Florida <br/>
+Michelle LeFebvre (contributor) - University of Florida <br/>
+Neill Wallis (contributor) - University of Florida <br/>
+Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Marie Elise Lecoq (contributor) <br/>
+Eric Kansa (contributor) - Harvard University <br/>
+Sarah Kansa (contributor) - The Alexandria Archive Institute <br/>
+Denné Reed (contributor) - University of Texas at Austin <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** The Chronometric Age Vocabulary is a standard for transmitting information about chronometric ages - the processes and results of an assay or other analysis used to determine the age of a MaterialSample. This document lists all terms in namespaces currently used in the vocabulary. <br/>
 **Citation:** TDWG Darwin Core Chronometric Age Extension Task Group. 2021. Chronometric Age Vocabulary List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/dwc/doc/chrono/2021-04-27
 

--- a/content/pages/standards/economic-botany/index.md
+++ b/content/pages/standards/economic-botany/index.md
@@ -42,14 +42,14 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Economic Botany Data Collection Standard \
-**Permanent IRI:** [http://rs.tdwg.org/ebdc/doc/specification/](https://www.kew.org/tdwguses/index.htm) \
-**Created:** 1995 \
-**Last modified:** 1995 \
-**Contributors:** \
-Frances E. M. Cook (author) - Royal Botanic Gardens, Kew \
-**Publisher:** Royal Botanic Gardens, Kew \
-**Abstract:** The aim of the Economic Botany Data Collection Standard is to provide a system whereby uses of plants (in their cultural context) can be described, using standardised descriptors and terms, and attached to taxonomic data sets. This book describes the structure and implementation of the standard. \
-**Note:** This document was available in print.  The linked document is a scan of the print book. \
+**Title:** Economic Botany Data Collection Standard <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ebdc/doc/specification/](https://www.kew.org/tdwguses/index.htm) <br/>
+**Created:** 1995 <br/>
+**Last modified:** 1995 <br/>
+**Contributors:** <br/>
+Frances E. M. Cook (author) - Royal Botanic Gardens, Kew <br/>
+**Publisher:** Royal Botanic Gardens, Kew <br/>
+**Abstract:** The aim of the Economic Botany Data Collection Standard is to provide a system whereby uses of plants (in their cultural context) can be described, using standardised descriptors and terms, and attached to taxonomic data sets. This book describes the structure and implementation of the standard. <br/>
+**Note:** This document was available in print.  The linked document is a scan of the print book. <br/>
 **Citation:** Cook, Frances E. M. 1995. Economic Botany Data Collection Standard. Prepared for the International Working Group on Taxonomic Databases for Plant Sciences (TDWG) by the Royal Botanic Gardens, Kew. ISBN 0947643710.  http://rs.tdwg.org/ebdc/doc/specification/
 

--- a/content/pages/standards/floristic-regions/index.md
+++ b/content/pages/standards/floristic-regions/index.md
@@ -37,16 +37,16 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Floristic Regions of the World \
-**Permanent IRI:** [http://rs.tdwg.org/frw/doc/book/](https://github.com/tdwg/prior-standards/tree/master/floristic-regions-of-the-world) \
-**Created:** 1986-09-04 \
-**Last modified:** 1986-09-04 \
-**Contributors:** \
-Armen Leonovich Takhtajan (author) \
-Theodore J. Crovello (translator) \
-Arthur Cronquist (editor) \
-**Publisher:** University of California Press  \
-**Abstract:** This book describes the floristic divisions for the whole world, lists endemic families and genera, and provides examples of endemic species for each province. \
-**Note:** First English Language Edition. Seems to be available in print only. \
+**Title:** Floristic Regions of the World <br/>
+**Permanent IRI:** [http://rs.tdwg.org/frw/doc/book/](https://github.com/tdwg/prior-standards/tree/master/floristic-regions-of-the-world) <br/>
+**Created:** 1986-09-04 <br/>
+**Last modified:** 1986-09-04 <br/>
+**Contributors:** <br/>
+Armen Leonovich Takhtajan (author) <br/>
+Theodore J. Crovello (translator) <br/>
+Arthur Cronquist (editor) <br/>
+**Publisher:** University of California Press  <br/>
+**Abstract:** This book describes the floristic divisions for the whole world, lists endemic families and genera, and provides examples of endemic species for each province. <br/>
+**Note:** First English Language Edition. Seems to be available in print only. <br/>
 **Citation:** Takhtajan, A. L. 1986. Floristic Regions of the World. University of California Press. Berkeley, Los Angeles, London. xxii, 522 pp., 4 maps. ISBN 0520040279. http://rs.tdwg.org/frw/doc/book/
 

--- a/content/pages/standards/guid-as/index.md
+++ b/content/pages/standards/guid-as/index.md
@@ -40,30 +40,30 @@ This standard is comprised of 2 documents.
 
 Documents:
 
-**Title:** Globally Unique Identifiers Applicability Statement \
-**Permanent IRI:** [http://rs.tdwg.org/guid/doc/guidas/](https://github.com/tdwg/guid-as/blob/master/guid/tdwg_guid_applicability_statement.pdf) \
-**Created:** 2010-09-09 \
-**Last modified:** 2010-09-09 \
-**Contributors:** \
-Kevin Richards (lead author) - Landcare Research \
-Ben Richardson (review manager) - Department of Environment and Conservation, Western Australia \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document provides guidance on how to use GUIDs (Globally Unique Identifiers) to meet specific requirements of the biodiversity information community.  It applies to GUIDs in general; there is, or will be, a separate document for the applicability of each specific GUID technology. \
+**Title:** Globally Unique Identifiers Applicability Statement <br/>
+**Permanent IRI:** [http://rs.tdwg.org/guid/doc/guidas/](https://github.com/tdwg/guid-as/blob/master/guid/tdwg_guid_applicability_statement.pdf) <br/>
+**Created:** 2010-09-09 <br/>
+**Last modified:** 2010-09-09 <br/>
+**Contributors:** <br/>
+Kevin Richards (lead author) - Landcare Research <br/>
+Ben Richardson (review manager) - Department of Environment and Conservation, Western Australia <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document provides guidance on how to use GUIDs (Globally Unique Identifiers) to meet specific requirements of the biodiversity information community.  It applies to GUIDs in general; there is, or will be, a separate document for the applicability of each specific GUID technology. <br/>
 **Citation:** Globally Unique Identifiers Task Group. 2011. Globally Unique Identifiers (GUID) Applicability Statement. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/guid/doc/guidas/
 
-**Title:** Life Sciences Identifiers (LSID) Applicability Statement \
-**Permanent IRI:** [http://rs.tdwg.org/guid/doc/lsidas/](https://github.com/tdwg/guid-as/blob/master/lsid/tdwg_lsid_applicability_statement.pdf) \
-**Created:** 2009-09-03 \
-**Last modified:** 2009-09-03 \
-**Contributors:** \
-Ricardo Scachetti-Pereira (author) - TDWG Infrastructure Project \
-Kevin Richards (author) - Landcare Research \
-Donald Hobern (author) - Global Biodiversity Information Facility \
-Roger Hyam (author) - TDWG Infrastructure Project \
-Lee Belbin (author) - TDWG Infrastructure Project \
-Stanley Blum (author) - California Academy of Sciences \
-Ben Richardson (review manager) - Department of Environment and Conservation, Western Australia \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document provides guidance on how to use LSID to meet specific requirements of the biodiversity information community; and defines how to identify shared data objects in biodiversity information applications using Life Sciences Identifiers (LSID). It should be read in conjunction with the GUID Applicability Statement \
+**Title:** Life Sciences Identifiers (LSID) Applicability Statement <br/>
+**Permanent IRI:** [http://rs.tdwg.org/guid/doc/lsidas/](https://github.com/tdwg/guid-as/blob/master/lsid/tdwg_lsid_applicability_statement.pdf) <br/>
+**Created:** 2009-09-03 <br/>
+**Last modified:** 2009-09-03 <br/>
+**Contributors:** <br/>
+Ricardo Scachetti-Pereira (author) - TDWG Infrastructure Project <br/>
+Kevin Richards (author) - Landcare Research <br/>
+Donald Hobern (author) - Global Biodiversity Information Facility <br/>
+Roger Hyam (author) - TDWG Infrastructure Project <br/>
+Lee Belbin (author) - TDWG Infrastructure Project <br/>
+Stanley Blum (author) - California Academy of Sciences <br/>
+Ben Richardson (review manager) - Department of Environment and Conservation, Western Australia <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document provides guidance on how to use LSID to meet specific requirements of the biodiversity information community; and defines how to identify shared data objects in biodiversity information applications using Life Sciences Identifiers (LSID). It should be read in conjunction with the GUID Applicability Statement <br/>
 **Citation:** Globally Unique Identifiers Task Group. 2011. Life Science Identifiers (LSID) Applicability Statement. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/guid/doc/lsidas/
 

--- a/content/pages/standards/hispid3/index.md
+++ b/content/pages/standards/hispid3/index.md
@@ -42,13 +42,13 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** HISPID3 Herbarium Information Standards and Protocols for Interchange of Data \
-**Permanent IRI:** [http://rs.tdwg.org/hispid/doc/specification/](https://raw.githack.com/tdwg/prior-standards/master/hispid3/110-540-1-RV.html) \
-**Created:** 1989 \
-**Last modified:** 2007-05-11 \
-**Contributors:** \
-Barry J. Conn (editor) \
-**Publisher:** Council of Heads of Australian Herbaria \
-**Abstract:** This document describes the form of HISPID3 records and the fields that can be included in an interchange flat file. \
+**Title:** HISPID3 Herbarium Information Standards and Protocols for Interchange of Data <br/>
+**Permanent IRI:** [http://rs.tdwg.org/hispid/doc/specification/](https://raw.githack.com/tdwg/prior-standards/master/hispid3/110-540-1-RV.html) <br/>
+**Created:** 1989 <br/>
+**Last modified:** 2007-05-11 <br/>
+**Contributors:** <br/>
+Barry J. Conn (editor) <br/>
+**Publisher:** Council of Heads of Australian Herbaria <br/>
+**Abstract:** This document describes the form of HISPID3 records and the fields that can be included in an interchange flat file. <br/>
 **Citation:** Herbarium Information Systems Committee. 2007. HISPID3 Herbarium Information Standards and Protocols for Interchange of Data. Council of Heads of Australian Herbaria. http://rs.tdwg.org/hispid/doc/specification/
 

--- a/content/pages/standards/ih/index.md
+++ b/content/pages/standards/ih/index.md
@@ -35,16 +35,16 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Index Herbariorum. Part I: The Herbaria of the World (Regnum Vegetabile, Vol. 120, eighth edition) \
-**Permanent IRI:** [http://rs.tdwg.org/ih/doc/book/](http://sweetgum.nybg.org/science/ih/) \
-**Created:** 1990 \
-**Last modified:** 1990 \
-**Contributors:** \
-Patricia K. Holmgren (editor) \
-Noel H. Holmgren (editor) \
-Lisa C. Barnett (editor) \
-**Publisher:** New Your Botanical Gardens \
-**Abstract:** Index Herbariorum is a guide to the world's herbaria.  The Index Herbariorum (IH) entry for an herbarium includes its physical location, URL, contents (e.g., number and type of specimens), founding date, as well as names, contact information and areas of expertise of associated staff. Only those collections that are permanent scientific repositories are included in IH. \
-**Note:** Online database at http://sweetgum.nybg.org/science/ih/ \
+**Title:** Index Herbariorum. Part I: The Herbaria of the World (Regnum Vegetabile, Vol. 120, eighth edition) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/ih/doc/book/](http://sweetgum.nybg.org/science/ih/) <br/>
+**Created:** 1990 <br/>
+**Last modified:** 1990 <br/>
+**Contributors:** <br/>
+Patricia K. Holmgren (editor) <br/>
+Noel H. Holmgren (editor) <br/>
+Lisa C. Barnett (editor) <br/>
+**Publisher:** New Your Botanical Gardens <br/>
+**Abstract:** Index Herbariorum is a guide to the world's herbaria.  The Index Herbariorum (IH) entry for an herbarium includes its physical location, URL, contents (e.g., number and type of specimens), founding date, as well as names, contact information and areas of expertise of associated staff. Only those collections that are permanent scientific repositories are included in IH. <br/>
+**Note:** Online database at http://sweetgum.nybg.org/science/ih/ <br/>
 **Citation:** Holmgren, P. K., N. H. Holmgren, and L. C. Barnett. 1990. Index Herbariorum. Part I: The Herbaria of the World (Regnum Vegetabile, Vol. 120, eighth edition). New York Botanical Gardens. ISBN: 0893273589. http://rs.tdwg.org/ih/doc/book/
 

--- a/content/pages/standards/itf2/index.md
+++ b/content/pages/standards/itf2/index.md
@@ -40,23 +40,23 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** The International Transfer Format (ITF) for Botanic Garden Plant Records (Version 2) \
-**Permanent IRI:** [http://rs.tdwg.org/itfbgpr/doc/specification/](http://www.bgci.org/files/Databases/itf2.pdf) \
-**Created:** 1987-09-15 \
-**Last modified:** 1998 \
-**Contributors:** \
-Diane Wyse Jackson (lead author) - Botanic Gardens Conservation International \
-Christopher Hobson (editor) - Botanic Gardens Conservation International \
-Barry Conn (editor) - Botanic Gardens Conservation International \
-Richard Piacentini (editor) - Botanic Gardens Conservation International \
-Steve Waldren (editor) - Botanic Gardens Conservation International \
-Chris Ward (editor) - Botanic Gardens Conservation International \
-Ken Bailey (author) - Royal Botanic Garden, Kew \
-Peter Wyse Jackson (author) - Botanic Gardens Conservation International \
-Simon Thornton Wood (author) - Royal Horticultural Society \
-Kerry Walter (author) - BG-BASE and Royal Botanic Garden, Edinburgh \
-**Publisher:** Botanic Gardens Conservation International \
-**Abstract:** This document contains a complete description of version 2 of the International Transfer Format for Botanic Garden Records. It includes all the information which institutions will need when making use of the ITF2 to send or receive plant records in the ITF2 format. The annexes to this manual describe some of the problem areas which needed to be addressed during the definition of ITF2.  \
-**Note:** Available only in electronic format. \
+**Title:** The International Transfer Format (ITF) for Botanic Garden Plant Records (Version 2) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/itfbgpr/doc/specification/](http://www.bgci.org/files/Databases/itf2.pdf) <br/>
+**Created:** 1987-09-15 <br/>
+**Last modified:** 1998 <br/>
+**Contributors:** <br/>
+Diane Wyse Jackson (lead author) - Botanic Gardens Conservation International <br/>
+Christopher Hobson (editor) - Botanic Gardens Conservation International <br/>
+Barry Conn (editor) - Botanic Gardens Conservation International <br/>
+Richard Piacentini (editor) - Botanic Gardens Conservation International <br/>
+Steve Waldren (editor) - Botanic Gardens Conservation International <br/>
+Chris Ward (editor) - Botanic Gardens Conservation International <br/>
+Ken Bailey (author) - Royal Botanic Garden, Kew <br/>
+Peter Wyse Jackson (author) - Botanic Gardens Conservation International <br/>
+Simon Thornton Wood (author) - Royal Horticultural Society <br/>
+Kerry Walter (author) - BG-BASE and Royal Botanic Garden, Edinburgh <br/>
+**Publisher:** Botanic Gardens Conservation International <br/>
+**Abstract:** This document contains a complete description of version 2 of the International Transfer Format for Botanic Garden Records. It includes all the information which institutions will need when making use of the ITF2 to send or receive plant records in the ITF2 format. The annexes to this manual describe some of the problem areas which needed to be addressed during the definition of ITF2.  <br/>
+**Note:** Available only in electronic format. <br/>
 **Citation:** Wyse Jackson, D., C. Hobson, B. Conn, R. Piacentini, S. Waldren, C. Ward, K. Bailey, P. Wyse Jackson, S. T. Wood, K. Walter. 1998. The International Transfer Format (ITF) for Botanic Garden Plant Records (Version 2). Botanic Gardens Conservation International. http://rs.tdwg.org/itfbgpr/doc/specification/
 

--- a/content/pages/standards/plant-names-authors/index.md
+++ b/content/pages/standards/plant-names-authors/index.md
@@ -47,15 +47,15 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Authors of Plant Names \
-**Permanent IRI:** [http://rs.tdwg.org/apn/doc/data/](https://www.kew.org/data/authors.html) \
-**Created:** 1992 \
-**Last modified:** 1992 \
-**Contributors:** \
-Richard K. Brummitt (author) \
-C. Emma Powell (author) \
-**Publisher:** Royal Botanic Gardens, Kew \
-**Abstract:** An index of authors of plant scientific names. Includes flowering plants, gymnosperms, pteridophytes, bryophytes, algae, fungi and fossil plants. Full names, dates of birth and death when known, recommended abbreviations and groups in which names have been published, are given for each author.  \
-**Note:** Note: Authors of Plant Names eBook is behind a GBP 60 paywall (http://shop.kew.org/authors-of-plant-names-11770).  Since 1998, the database of author names and their standard forms has been maintained and updated online as part of The International Plant Names Index (http://www.ipni.org/). \
+**Title:** Authors of Plant Names <br/>
+**Permanent IRI:** [http://rs.tdwg.org/apn/doc/data/](https://www.kew.org/data/authors.html) <br/>
+**Created:** 1992 <br/>
+**Last modified:** 1992 <br/>
+**Contributors:** <br/>
+Richard K. Brummitt (author) <br/>
+C. Emma Powell (author) <br/>
+**Publisher:** Royal Botanic Gardens, Kew <br/>
+**Abstract:** An index of authors of plant scientific names. Includes flowering plants, gymnosperms, pteridophytes, bryophytes, algae, fungi and fossil plants. Full names, dates of birth and death when known, recommended abbreviations and groups in which names have been published, are given for each author.  <br/>
+**Note:** Note: Authors of Plant Names eBook is behind a GBP 60 paywall (http://shop.kew.org/authors-of-plant-names-11770).  Since 1998, the database of author names and their standard forms has been maintained and updated online as part of The International Plant Names Index (http://www.ipni.org/). <br/>
 **Citation:** Brummitt, R. K. and C. E. Powell. 1992. Authors of Plant Names. Kew Publishing. ISBN: 1842460854 http://rs.tdwg.org/apn/doc/data/1992
 

--- a/content/pages/standards/plant-names/index.md
+++ b/content/pages/standards/plant-names/index.md
@@ -40,14 +40,14 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Plant Names in Botanical Databases \
-**Permanent IRI:** [http://rs.tdwg.org/pnbd/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/plant-names-in-botanical-databases/113-528-1-RV.pdf) \
-**Created:** 1994-12 \
-**Last modified:** 1994-12 \
-**Contributors:** \
-Frank A Bisby  (author) - University of Southampton  \
-**Publisher:** Hunt Institute for Botanical Documentation \
-**Abstract:** This standard defines the taxonomic and nomenclatural concepts associated with the names of plants. It describes the component parts, their functions and their interrelations of significance in structuring a database.  \
-**Note:** Note: the introduction of this publication provides some historical information about TDWG and early standards it produced or adopted from elsewhere. \
+**Title:** Plant Names in Botanical Databases <br/>
+**Permanent IRI:** [http://rs.tdwg.org/pnbd/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/plant-names-in-botanical-databases/113-528-1-RV.pdf) <br/>
+**Created:** 1994-12 <br/>
+**Last modified:** 1994-12 <br/>
+**Contributors:** <br/>
+Frank A Bisby  (author) - University of Southampton  <br/>
+**Publisher:** Hunt Institute for Botanical Documentation <br/>
+**Abstract:** This standard defines the taxonomic and nomenclatural concepts associated with the names of plants. It describes the component parts, their functions and their interrelations of significance in structuring a database.  <br/>
+**Note:** Note: the introduction of this publication provides some historical information about TDWG and early standards it produced or adopted from elsewhere. <br/>
 **Citation:** TDWG Minimum Standard for Names in Botanical Databases Subgroup (Author: Frank A. Bisby). 1994. Plant Names in Botanical Databases. Hunt Institute for Botanical Documentation. http://rs.tdwg.org/pnbd/doc/specification/
 

--- a/content/pages/standards/poss/index.md
+++ b/content/pages/standards/poss/index.md
@@ -37,13 +37,13 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Plant Occurrence and Status Scheme: A Standard for Recording the Relationship between a Plant and a Place \
-**Permanent IRI:** [http://rs.tdwg.org/poss/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/poss/106-522-1-RV.pdf) \
-**Created:** 1995-11 \
-**Last modified:** 1995-11 \
-**Contributors:** \
-Hugh Synge (author) - IUCN Conservation Monitoring Centre \
-**Publisher:** International Working Group on Taxonomic Databases (TDWG) \
-**Abstract:** This document describes the general principles of POSS and describes the data fields and their suggested values. \
+**Title:** Plant Occurrence and Status Scheme: A Standard for Recording the Relationship between a Plant and a Place <br/>
+**Permanent IRI:** [http://rs.tdwg.org/poss/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/poss/106-522-1-RV.pdf) <br/>
+**Created:** 1995-11 <br/>
+**Last modified:** 1995-11 <br/>
+**Contributors:** <br/>
+Hugh Synge (author) - IUCN Conservation Monitoring Centre <br/>
+**Publisher:** International Working Group on Taxonomic Databases (TDWG) <br/>
+**Abstract:** This document describes the general principles of POSS and describes the data fields and their suggested values. <br/>
 **Citation:** World Conservation Monitoring Centre. 1995. Plant Occurrence and Status Scheme: A Standard for Recording the Relationship between a Plant and a Place. International Working Group on Taxonomic Databases (TDWG). http://rs.tdwg.org/poss/doc/specification/
 

--- a/content/pages/standards/sdd/index.md
+++ b/content/pages/standards/sdd/index.md
@@ -40,29 +40,29 @@ This standard is comprised of 2 documents.
 
 Documents:
 
-**Title:** Introduction and Primer to the Structured Descriptive Data (SDD) Standard \
-**Permanent IRI:** [http://rs.tdwg.org/sdd/doc/introduction/](https://github.com/tdwg/wiki-archive/blob/master/twiki/data/SDD/Primer/SddIntroduction.txt) \
-**Created:** 2006-05-11 \
-**Last modified:** 2006-05-11 \
-**Contributors:** \
-Gregor Hagedorn (author) - Julius Kühn Institute  \
-Kevin R. Thiele (author) - Western Australian Herbarium  \
-Robert A. Morris (author) - University of Massachusetts at Boston, USA \
-P. Bryan Heidorn (author) - University of Illinois at Urbana-Champaign \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document is a non-normative introduction to the Taxonomic Databases Working Group SDD (Structure of Descriptive Data) Standard. Its intention is to provide a background, introduction and primer to the SDD Standard, with examples. \
+**Title:** Introduction and Primer to the Structured Descriptive Data (SDD) Standard <br/>
+**Permanent IRI:** [http://rs.tdwg.org/sdd/doc/introduction/](https://github.com/tdwg/wiki-archive/blob/master/twiki/data/SDD/Primer/SddIntroduction.txt) <br/>
+**Created:** 2006-05-11 <br/>
+**Last modified:** 2006-05-11 <br/>
+**Contributors:** <br/>
+Gregor Hagedorn (author) - Julius Kühn Institute  <br/>
+Kevin R. Thiele (author) - Western Australian Herbarium  <br/>
+Robert A. Morris (author) - University of Massachusetts at Boston, USA <br/>
+P. Bryan Heidorn (author) - University of Illinois at Urbana-Champaign <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document is a non-normative introduction to the Taxonomic Databases Working Group SDD (Structure of Descriptive Data) Standard. Its intention is to provide a background, introduction and primer to the SDD Standard, with examples. <br/>
 **Citation:** Structure of Descriptive Data (SDD) Subgroup. 2006. Introduction and Primer to the Structured Descriptive Data (SDD) Standard. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/sdd/doc/introduction/
 
-**Title:** Structured Descriptive Data XML Schema \
-**Permanent IRI:** [http://rs.tdwg.org/sdd/doc/xmlschema/](https://github.com/tdwg/sdd/blob/master/2006/Schema/1.1/SDD.xsd) \
-**Created:** 2006-05-11 \
-**Last modified:** 2006-05-11 \
-**Contributors:** \
-Gregor Hagedorn (author) - Julius Kühn Institute  \
-Kevin R. Thiele (author) - Western Australian Herbarium  \
-Robert A. Morris (author) - University of Massachusetts at Boston, USA \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This is the schema file to be referenced in instance documents for validation. It is the top level schema file that integrates the schema components.  \
-**Note:** See also https://raw.githack.com/tdwg/sdd/master/2006/rddl.html and https://github.com/tdwg/sdd/blob/master/2006/Schema/1.1/UBIF_(c).xsd \
+**Title:** Structured Descriptive Data XML Schema <br/>
+**Permanent IRI:** [http://rs.tdwg.org/sdd/doc/xmlschema/](https://github.com/tdwg/sdd/blob/master/2006/Schema/1.1/SDD.xsd) <br/>
+**Created:** 2006-05-11 <br/>
+**Last modified:** 2006-05-11 <br/>
+**Contributors:** <br/>
+Gregor Hagedorn (author) - Julius Kühn Institute  <br/>
+Kevin R. Thiele (author) - Western Australian Herbarium  <br/>
+Robert A. Morris (author) - University of Massachusetts at Boston, USA <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This is the schema file to be referenced in instance documents for validation. It is the top level schema file that integrates the schema components.  <br/>
+**Note:** See also https://raw.githack.com/tdwg/sdd/master/2006/rddl.html and https://github.com/tdwg/sdd/blob/master/2006/Schema/1.1/UBIF_(c).xsd <br/>
 **Citation:** Structure of Descriptive Data (SDD) Subgroup. 2006. Structured Descriptive Data XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/sdd/doc/xmlschema/
 

--- a/content/pages/standards/sds/index.md
+++ b/content/pages/standards/sds/index.md
@@ -40,21 +40,21 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Standards Documentation Specification \
-**Permanent IRI:** [http://rs.tdwg.org/sds/doc/specification/](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md) \
-**Created:** 2007-11-05 \
-**Last modified:** 2017-04-25 \
-**Contributors:** \
-Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group \
-Roger Hyam (author) - TDWG Infrastructure Project \
-Stanley Blum (author) - TDWG Process Interest Group \
-Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group \
-Jonathan Rees (author) - Duke University \
-Joel Sachs (author) - TDWG RDF Task Group \
-Greg Whitbread (author) - TDWG Technical Architecture Group \
-John Wieczorek (author) - TDWG Darwin Core Task Group \
-Dag Endresen (review manager) - GBIF Norway/NHM University of Oslo \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms. \
+**Title:** Standards Documentation Specification <br/>
+**Permanent IRI:** [http://rs.tdwg.org/sds/doc/specification/](https://github.com/tdwg/vocab/blob/master/sds/documentation-specification.md) <br/>
+**Created:** 2007-11-05 <br/>
+**Last modified:** 2017-04-25 <br/>
+**Contributors:** <br/>
+Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group <br/>
+Roger Hyam (author) - TDWG Infrastructure Project <br/>
+Stanley Blum (author) - TDWG Process Interest Group <br/>
+Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group <br/>
+Jonathan Rees (author) - Duke University <br/>
+Joel Sachs (author) - TDWG RDF Task Group <br/>
+Greg Whitbread (author) - TDWG Technical Architecture Group <br/>
+John Wieczorek (author) - TDWG Darwin Core Task Group <br/>
+Dag Endresen (review manager) - GBIF Norway/NHM University of Oslo <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document defines how TDWG standards are to be presented. It provides details about the hierarchical structure of standards and versioning of standards components. It specifies how the properties of standards and their components are to be described in human-readable and machine-readable terms. <br/>
 **Citation:** Vocabulary Maintenance Specification Task Group. 2017. Standards Documentation Specification. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/sds/doc/specification/
 

--- a/content/pages/standards/tapir/index.md
+++ b/content/pages/standards/tapir/index.md
@@ -85,68 +85,68 @@ This standard is comprised of 6 documents.
 
 Documents:
 
-**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Protocol Specification \
-**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/specification/](http://tdwg.github.io/tapir/docs/tdwg_tapir_specification_2010-05-05.html) \
-**Created:** 2010-05-05 \
-**Last modified:** 2010-05-05 \
-**Contributors:** \
-Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
-Charles Copp (lead author) - Environmental Information Management  \
-Markus Döring (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-Anton Güntsch (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-Dave Vieglais (author) - KU Natural History Museum \
-Donald Hobern (author) - Global Biodiversity Information Facility \
-Javier de la Torre (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-John Wieczorek (author) - Museum of Vertebrate Zoology at Berkeley \
-Robert Gales (author) - KU Natural History Museum \
-Roger Hyam (author) - TDWG \
-Stanley Blum (author) - California Academy of Sciences \
-Perry Steven (author) - KU Natural History Museum \
-Piers Higgs (review manager) \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document specifies the TAPIR protocol and the structure and syntax of TAPIR messages.   \
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Protocol Specification <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/specification/](http://tdwg.github.io/tapir/docs/tdwg_tapir_specification_2010-05-05.html) <br/>
+**Created:** 2010-05-05 <br/>
+**Last modified:** 2010-05-05 <br/>
+**Contributors:** <br/>
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental <br/>
+Charles Copp (lead author) - Environmental Information Management  <br/>
+Markus Döring (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+Anton Güntsch (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+Dave Vieglais (author) - KU Natural History Museum <br/>
+Donald Hobern (author) - Global Biodiversity Information Facility <br/>
+Javier de la Torre (author) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+John Wieczorek (author) - Museum of Vertebrate Zoology at Berkeley <br/>
+Robert Gales (author) - KU Natural History Museum <br/>
+Roger Hyam (author) - TDWG <br/>
+Stanley Blum (author) - California Academy of Sciences <br/>
+Perry Steven (author) - KU Natural History Museum <br/>
+Piers Higgs (review manager) <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document specifies the TAPIR protocol and the structure and syntax of TAPIR messages.   <br/>
 **Citation:** TAPIR Task Group. 2010. TDWG Access Protocol for Information Retrieval (TAPIR) Protocol Specification. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/specification/
 
-**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) XML Schema  \
-**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/xmlschema/](http://tdwg.github.io/tapir/schema/tapir.xsd) \
-**Created:** 2009-02-05 \
-**Last modified:** 2009-02-05 \
-**Contributors:** \
-Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** TAPIR XML Schema. TAPIR is an acronym for TDWG Access Protocol for Information Retrieval. It is a unified and extended protocol based on DiGIR and BioCASe. TAPIR specifies a standardised, stateless, HTTP transmittable, XML-based request and response protocol for accessing structured data that may be stored on any number of distributed databases of varied physical and logical structure.   \
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) XML Schema  <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/xmlschema/](http://tdwg.github.io/tapir/schema/tapir.xsd) <br/>
+**Created:** 2009-02-05 <br/>
+**Last modified:** 2009-02-05 <br/>
+**Contributors:** <br/>
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** TAPIR XML Schema. TAPIR is an acronym for TDWG Access Protocol for Information Retrieval. It is a unified and extended protocol based on DiGIR and BioCASe. TAPIR specifies a standardised, stateless, HTTP transmittable, XML-based request and response protocol for accessing structured data that may be stored on any number of distributed databases of varied physical and logical structure.   <br/>
 **Citation:** TAPIR Task Group. 2009. TDWG Access Protocol for Information Retrieval (TAPIR) XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/xmlschema/
 
-**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Concept Aliases \
-**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/conceptaliases/](http://tdwg.github.io/tapir/cns/alias.txt) \
-**Created:** 2015-06-01 \
-**Last modified:** 2015-06-01 \
-**Contributors:** \
-Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** Globally unique aliases for concepts. The aliases listed here are only unique within their concept source.  \
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Concept Aliases <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/conceptaliases/](http://tdwg.github.io/tapir/cns/alias.txt) <br/>
+**Created:** 2015-06-01 <br/>
+**Last modified:** 2015-06-01 <br/>
+**Contributors:** <br/>
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** Globally unique aliases for concepts. The aliases listed here are only unique within their concept source.  <br/>
 **Citation:** TAPIR Task Group. 2015. TDWG Access Protocol for Information Retrieval (TAPIR) Concept Aliases. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/conceptaliases/
 
-**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Network Builders' Guide \
-**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/guide/](http://tdwg.github.io/tapir/docs/TAPIRNetworkBuildersGuide_2010-05-05.html) \
-**Created:** 2015-06-03 \
-**Last modified:** 2015-06-03 \
-**Contributors:** \
-Charles Copp (lead author) - Environmental Information Management  \
-Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
-Lee Belbin (reviewer) - TDWG Infrastructure Project \
-Markus Döring (reviewer) - Botanic Garden and Botanical Museum Berlin-Dahlem  \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document provides guidelines for building networks based on the TAPIR protocol.   \
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Network Builders' Guide <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/guide/](http://tdwg.github.io/tapir/docs/TAPIRNetworkBuildersGuide_2010-05-05.html) <br/>
+**Created:** 2015-06-03 <br/>
+**Last modified:** 2015-06-03 <br/>
+**Contributors:** <br/>
+Charles Copp (lead author) - Environmental Information Management  <br/>
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental <br/>
+Lee Belbin (reviewer) - TDWG Infrastructure Project <br/>
+Markus Döring (reviewer) - Botanic Garden and Botanical Museum Berlin-Dahlem  <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document provides guidelines for building networks based on the TAPIR protocol.   <br/>
 **Citation:** TAPIR Task Group. 2015. TDWG Access Protocol for Information Retrieval (TAPIR) Network Builders' Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/guide/
 
-**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Output Models and Query Templates \
-**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/models/](http://tdwg.github.io/tapir/cs/) \
-**Created:** 2015-11-25 \
-**Last modified:** 2015-11-25 \
-**Contributors:** \
-Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This page is an index to TAPIR XML models and query templates. \
+**Title:** TDWG Access Protocol for Information Retrieval (TAPIR) Output Models and Query Templates <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tapir/doc/models/](http://tdwg.github.io/tapir/cs/) <br/>
+**Created:** 2015-11-25 <br/>
+**Last modified:** 2015-11-25 <br/>
+**Contributors:** <br/>
+Renato De Giovanni (lead author) - Centro de Referência em Informação Ambiental <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This page is an index to TAPIR XML models and query templates. <br/>
 **Citation:** TAPIR Task Group. 2015. TDWG Access Protocol for Information Retrieval (TAPIR) Output Models and Query Templates. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tapir/doc/models/
 

--- a/content/pages/standards/tcs/index.md
+++ b/content/pages/standards/tcs/index.md
@@ -43,25 +43,25 @@ This standard is comprised of 2 documents.
 
 Documents:
 
-**Title:** Taxon Concept Schema User Guide \
-**Permanent IRI:** [http://rs.tdwg.org/tcs/doc/guide/](https://github.com/tdwg/tcs/blob/master/TCS101/UserGuidev_1.3.pdf) \
-**Created:** 2006-09-21 \
-**Last modified:** 2006-09-21 \
-**Contributors:** \
-Jessie Kennedy (author) - Napier University  \
-Roger Hyam (author) - TDWG Infrastructure Project \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This guide is meant to act as a readable introduction to the Taxon Concept Schema (TCS). It is aimed at both decision makers and implementers of systems and so the content varies from being of a general nature, assuming little prior knowledge of taxonomy or XML technologies, to being quite detailed concerning the technicalities of biological nomenclature and XML schemas. Generally it becomes more specific as it goes on. This document is not a step by step manual for mapping a data source to a TCS document. Each data source is likely to be different in structure and so this is not a feasible exercise. What it attempts to do is provided the information needed for an implementer to make intelligent decisions as to how their data source should be mapped to the schema so that they can publish and/or receive data from other systems with as little confusion as possible.  \
+**Title:** Taxon Concept Schema User Guide <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tcs/doc/guide/](https://github.com/tdwg/tcs/blob/master/TCS101/UserGuidev_1.3.pdf) <br/>
+**Created:** 2006-09-21 <br/>
+**Last modified:** 2006-09-21 <br/>
+**Contributors:** <br/>
+Jessie Kennedy (author) - Napier University  <br/>
+Roger Hyam (author) - TDWG Infrastructure Project <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This guide is meant to act as a readable introduction to the Taxon Concept Schema (TCS). It is aimed at both decision makers and implementers of systems and so the content varies from being of a general nature, assuming little prior knowledge of taxonomy or XML technologies, to being quite detailed concerning the technicalities of biological nomenclature and XML schemas. Generally it becomes more specific as it goes on. This document is not a step by step manual for mapping a data source to a TCS document. Each data source is likely to be different in structure and so this is not a feasible exercise. What it attempts to do is provided the information needed for an implementer to make intelligent decisions as to how their data source should be mapped to the schema so that they can publish and/or receive data from other systems with as little confusion as possible.  <br/>
 **Citation:** Taxonomic Names Subgroup. 2006. Taxon Concept Schema User Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tcs/doc/guide/
 
-**Title:** Taxon Concept Schema XML Schema \
-**Permanent IRI:** [http://rs.tdwg.org/tcs/doc/xmlschema/](https://github.com/tdwg/tcs/blob/master/TCS101/v101.xsd) \
-**Created:** 2006-09-21 \
-**Last modified:** 2006-09-21 \
-**Contributors:** \
-Jessie Kennedy (author) - Napier University  \
-Roger Hyam (author) - TDWG Infrastructure Project \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document is the validation schema for Taxon Concept Schema XML documents. \
+**Title:** Taxon Concept Schema XML Schema <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tcs/doc/xmlschema/](https://github.com/tdwg/tcs/blob/master/TCS101/v101.xsd) <br/>
+**Created:** 2006-09-21 <br/>
+**Last modified:** 2006-09-21 <br/>
+**Contributors:** <br/>
+Jessie Kennedy (author) - Napier University  <br/>
+Roger Hyam (author) - TDWG Infrastructure Project <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document is the validation schema for Taxon Concept Schema XML documents. <br/>
 **Citation:** Taxonomic Names Subgroup. 2006. Taxon Concept Schema XML Schema. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tcs/doc/xmlschema/
 

--- a/content/pages/standards/tl-2/index.md
+++ b/content/pages/standards/tl-2/index.md
@@ -39,183 +39,183 @@ This standard is comprised of 15 documents.
 
 Documents:
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 1) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v1/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1976 \
-**Last modified:** 1976 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors A-G. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 1) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v1/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1976 <br/>
+**Last modified:** 1976 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors A-G. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1976. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 1). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v1/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 2) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v2/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1979 \
-**Last modified:** 1979 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors H-Le. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 2) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v2/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1979 <br/>
+**Last modified:** 1979 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors H-Le. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1979. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 2). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v2/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 3) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v3/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1981 \
-**Last modified:** 1981 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors Lh-O. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 3) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v3/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1981 <br/>
+**Last modified:** 1981 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors Lh-O. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1981. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 3). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v3/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 4) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v4/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1983 \
-**Last modified:** 1983 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors P-Sak. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 4) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v4/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1983 <br/>
+**Last modified:** 1983 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors P-Sak. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1983. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 4). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v4/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 5) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v5/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1985 \
-**Last modified:** 1985 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors Sal-Ste. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 5) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v5/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1985 <br/>
+**Last modified:** 1985 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors Sal-Ste. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1985. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 5). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v5/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 6) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v6/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1986 \
-**Last modified:** 1986 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors Sti-Vuy. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 6) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v6/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1986 <br/>
+**Last modified:** 1986 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors Sti-Vuy. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1986. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 6). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v6/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 7) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v7/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1988 \
-**Last modified:** 1988 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Richard S. Cowan (author) \
-**Publisher:** Bohn, Scheltema, and Holkema \
-**Abstract:** Authors W-Z. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 7) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/v7/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1988 <br/>
+**Last modified:** 1988 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Richard S. Cowan (author) <br/>
+**Publisher:** Bohn, Scheltema, and Holkema <br/>
+**Abstract:** Authors W-Z. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and R. S. Cowan. 1988. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (Second edition, vol. 7). Bohn, Scheltema, and Holkema. http://rs.tdwg.org/tl/doc/v7/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 1) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s1/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1992 \
-**Last modified:** 1992 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Erik A. Mennega (author) \
-**Publisher:** Koeltz Scientific Books \
-**Abstract:** Authors A-Ba. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 1) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s1/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1992 <br/>
+**Last modified:** 1992 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Erik A. Mennega (author) <br/>
+**Publisher:** Koeltz Scientific Books <br/>
+**Abstract:** Authors A-Ba. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and E. A. Mennega. 1992. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 1). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s1/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 2) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s2/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1993 \
-**Last modified:** 1993 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Erik A. Mennega (author) \
-**Publisher:** Koeltz Scientific Books \
-**Abstract:** Authors Be-Bo. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 2) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s2/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1993 <br/>
+**Last modified:** 1993 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Erik A. Mennega (author) <br/>
+**Publisher:** Koeltz Scientific Books <br/>
+**Abstract:** Authors Be-Bo. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and E. A. Mennega. 1993. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 2). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s2/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 3) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s3/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1995 \
-**Last modified:** 1995 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Erik A. Mennega (author) \
-**Publisher:** Koeltz Scientific Books \
-**Abstract:** Authors Br-Ca. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 3) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s3/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1995 <br/>
+**Last modified:** 1995 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Erik A. Mennega (author) <br/>
+**Publisher:** Koeltz Scientific Books <br/>
+**Abstract:** Authors Br-Ca. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and E. A. Mennega. 1995. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 3). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s3/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 4) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s4/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1997 \
-**Last modified:** 1997 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Erik A. Mennega (author) \
-**Publisher:** Koeltz Scientific Books \
-**Abstract:** Authors Ce-Cz. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 4) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s4/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1997 <br/>
+**Last modified:** 1997 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Erik A. Mennega (author) <br/>
+**Publisher:** Koeltz Scientific Books <br/>
+**Abstract:** Authors Ce-Cz. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and E. A. Mennega. 1997. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 4). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s4/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 5) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s5/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 1998 \
-**Last modified:** 1998 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Erik A. Mennega (author) \
-**Publisher:** Koeltz Scientific Books \
-**Abstract:** Authors Da-Di. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 5) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s5/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 1998 <br/>
+**Last modified:** 1998 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Erik A. Mennega (author) <br/>
+**Publisher:** Koeltz Scientific Books <br/>
+**Abstract:** Authors Da-Di. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and E. A. Mennega. 1998. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 5). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s5/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 6) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s6/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 2000 \
-**Last modified:** 2000 \
-**Contributors:** \
-Frans A. Stafleu (lead author) \
-Erik A. Mennega (author) \
-**Publisher:** Koeltz Scientific Books \
-**Abstract:** Authors Do-E. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 6) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s6/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 2000 <br/>
+**Last modified:** 2000 <br/>
+**Contributors:** <br/>
+Frans A. Stafleu (lead author) <br/>
+Erik A. Mennega (author) <br/>
+**Publisher:** Koeltz Scientific Books <br/>
+**Abstract:** Authors Do-E. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Stafleu, F. A. and E. A. Mennega. 2000. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 6). Koeltz Scientific Books. http://rs.tdwg.org/tl/doc/s6/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 7) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s7/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 2008 \
-**Last modified:** 2008 \
-**Contributors:** \
-Laurence J. Dorr (author) \
-Dan H. Nicolson (author) \
-**Publisher:** A.R.G. Gantner Verlag K.G. \
-**Abstract:** Authors F-Frer. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 7) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s7/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 2008 <br/>
+**Last modified:** 2008 <br/>
+**Contributors:** <br/>
+Laurence J. Dorr (author) <br/>
+Dan H. Nicolson (author) <br/>
+**Publisher:** A.R.G. Gantner Verlag K.G. <br/>
+**Abstract:** Authors F-Frer. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Dorr, L. J. and D. H. Nicolson. 2008. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 7). A.R.G. Gantner Verlag K.G. http://rs.tdwg.org/tl/doc/s7/
 
-**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 8) \
-**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s8/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) \
-**Created:** 2009 \
-**Last modified:** 2009 \
-**Contributors:** \
-Laurence J. Dorr (author) \
-Dan H. Nicolson (author) \
-**Publisher:** A.R.G. Gantner Verlag K.G. \
-**Abstract:** Authors Fres-G. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. \
-**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. \
+**Title:** Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 8) <br/>
+**Permanent IRI:** [http://rs.tdwg.org/tl/doc/s8/](http://www.sil.si.edu/DigitalCollections/tl-2/browse.cfm) <br/>
+**Created:** 2009 <br/>
+**Last modified:** 2009 <br/>
+**Contributors:** <br/>
+Laurence J. Dorr (author) <br/>
+Dan H. Nicolson (author) <br/>
+**Publisher:** A.R.G. Gantner Verlag K.G. <br/>
+**Abstract:** Authors Fres-G. Taxonomic Literature: a selective guide to botanical publications and collections with dates, commentaries and types, also known as TL-2, is an indispensable and essential resource that supports the research of systematic botanists and zoologists. In addition, TL-2 is an important reference tool in the science information field for librarians and information professionals working in Botany and other life sciences. Its coverage is international providing bibliographic analyses of works in many languages including English, French, German, and Latin. Overall, TL-2 provides the most comprehensive bibliographical and biographical coverage for systematic botany literature published between 1753 and 1940. <br/>
+**Note:** See http://www.sil.si.edu/DigitalCollections/tl-2/history.cfm for introduction. <br/>
 **Citation:** Dorr, L. J. and D. H. Nicolson. 2009. Taxonomic Literature : A Selective Guide to Botanical Publications and Collections with Dates, Commentaries and Types (supp. 8). A.R.G. Gantner Verlag K.G. http://rs.tdwg.org/tl/doc/s8/
 

--- a/content/pages/standards/vms/index.md
+++ b/content/pages/standards/vms/index.md
@@ -48,20 +48,20 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** Vocabulary Maintenance Specification \
-**Permanent IRI:** [http://rs.tdwg.org/vms/doc/specification/](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md) \
-**Created:** 2017-04-25 \
-**Last modified:** 2017-04-25 \
-**Contributors:** \
-Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group \
-John Wieczorek (author) - TDWG Darwin Core Task Group \
-Stanley Blum (author) - TDWG Process Interest Group \
-Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group \
-Jonathan Rees (author) - Duke University \
-Joel Sachs (author) - TDWG RDF Task Group \
-Greg Whitbread (author) - TDWG Technical Architecture Group \
-Dag Endresen (review manager) - GBIF Norway/NHM University of Oslo \
-**Publisher:** Biodiversity Information Standards (TDWG) \
-**Abstract:** This document describes the processes used to modify TDWG vocabularies and their associated documents. \
+**Title:** Vocabulary Maintenance Specification <br/>
+**Permanent IRI:** [http://rs.tdwg.org/vms/doc/specification/](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md) <br/>
+**Created:** 2017-04-25 <br/>
+**Last modified:** 2017-04-25 <br/>
+**Contributors:** <br/>
+Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group <br/>
+John Wieczorek (author) - TDWG Darwin Core Task Group <br/>
+Stanley Blum (author) - TDWG Process Interest Group <br/>
+Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group <br/>
+Jonathan Rees (author) - Duke University <br/>
+Joel Sachs (author) - TDWG RDF Task Group <br/>
+Greg Whitbread (author) - TDWG Technical Architecture Group <br/>
+Dag Endresen (review manager) - GBIF Norway/NHM University of Oslo <br/>
+**Publisher:** Biodiversity Information Standards (TDWG) <br/>
+**Abstract:** This document describes the processes used to modify TDWG vocabularies and their associated documents. <br/>
 **Citation:** Vocabulary Maintenance Specification Task Group. 2017. Vocabulary Maintenance Specification. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/vms/doc/specification/
 

--- a/content/pages/standards/wgsrpd/index.md
+++ b/content/pages/standards/wgsrpd/index.md
@@ -40,16 +40,16 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** World Geographic Scheme for Recording Plant Distributions \
-**Permanent IRI:** [http://rs.tdwg.org/wgsrpd/doc/data/](https://github.com/tdwg/wgsrpd/blob/master/109-488-1-ED/2nd%20Edition/TDWG_geo2.pdf) \
-**Created:** 2001-08 \
-**Last modified:** 2001-08 \
-**Contributors:** \
-Richard K. Brummitt (author) \
-Francisco Pando (author) \
-S. Hollis (author) \
-Neil A. Brummitt (author) \
-**Publisher:** Hunt Institute for Botanical Documentation \
-**Abstract:** This document defines a schem for recording geographical units.  The system offered covers the whole world and identifies units at four levels, firstly continental, secondly regional (or subcontinental), thirdly at what may be called “Botanical Country” level (which may often ignore purely political considerations), and fourthly at a slightly lower level called “Basic Recording Units” where political integrity is fully recognised. \
+**Title:** World Geographic Scheme for Recording Plant Distributions <br/>
+**Permanent IRI:** [http://rs.tdwg.org/wgsrpd/doc/data/](https://github.com/tdwg/wgsrpd/blob/master/109-488-1-ED/2nd%20Edition/TDWG_geo2.pdf) <br/>
+**Created:** 2001-08 <br/>
+**Last modified:** 2001-08 <br/>
+**Contributors:** <br/>
+Richard K. Brummitt (author) <br/>
+Francisco Pando (author) <br/>
+S. Hollis (author) <br/>
+Neil A. Brummitt (author) <br/>
+**Publisher:** Hunt Institute for Botanical Documentation <br/>
+**Abstract:** This document defines a schem for recording geographical units.  The system offered covers the whole world and identifies units at four levels, firstly continental, secondly regional (or subcontinental), thirdly at what may be called “Botanical Country” level (which may often ignore purely political considerations), and fourthly at a slightly lower level called “Basic Recording Units” where political integrity is fully recognised. <br/>
 **Citation:** R. K. Brummitt. 2001. World Geographic Scheme for Recording Plant Distributions, Edition 2. Hunt Institute for Botanical Documentation, Carnegie Mellon University (Pittsburgh). http://rs.tdwg.org/wgsrpd/doc/data/
 

--- a/content/pages/standards/xdf/index.md
+++ b/content/pages/standards/xdf/index.md
@@ -33,15 +33,15 @@ This standard is comprised of one document.
 
 Documents:
 
-**Title:** XDF: A Language for the Definition and Exchange of Biological Data Sets \
-**Permanent IRI:** [http://rs.tdwg.org/xdf/doc/article/](https://doi.org/10.1016/0895-7177(92)90163-F) \
-**Created:** 1992 \
-**Last modified:** 1992 \
-**Contributors:** \
-Richard J. White (author) \
-Robert Allkin (author) \
-**Publisher:** IUBS Commission for Plant Taxonomic Databases (TDWG) \
-**Abstract:** XDF (the Exchange Data Format) is a database file exchange medium to handle diverse classes of biological data required for file transfers between different database projects. Data sets prepared in XDF consists of text files that are effectively independent of any particular project. XDF is a high-level language for describing biological data, with its own syntax and command vocabulary, analogous to the high-level programming languages used to describe software algorithms.  \
-**Note:** Note: the article linked to the access uri does not seem to be the actual standard itself.  See reference number 16 in the article. \
+**Title:** XDF: A Language for the Definition and Exchange of Biological Data Sets <br/>
+**Permanent IRI:** [http://rs.tdwg.org/xdf/doc/article/](https://doi.org/10.1016/0895-7177(92)90163-F) <br/>
+**Created:** 1992 <br/>
+**Last modified:** 1992 <br/>
+**Contributors:** <br/>
+Richard J. White (author) <br/>
+Robert Allkin (author) <br/>
+**Publisher:** IUBS Commission for Plant Taxonomic Databases (TDWG) <br/>
+**Abstract:** XDF (the Exchange Data Format) is a database file exchange medium to handle diverse classes of biological data required for file transfers between different database projects. Data sets prepared in XDF consists of text files that are effectively independent of any particular project. XDF is a high-level language for describing biological data, with its own syntax and command vocabulary, analogous to the high-level programming languages used to describe software algorithms.  <br/>
+**Note:** Note: the article linked to the access uri does not seem to be the actual standard itself.  See reference number 16 in the article. <br/>
 **Citation:** TDWG XDF Subgroup (Authors: R. J. White and R. Allkin). 1992. XDF: A Language for the Definition and Exchange of Biological Data Sets. IUBS Commission for Plant Taxonomic Databases (TDWG). http://rs.tdwg.org/xdf/doc/article/
 


### PR DESCRIPTION
@stanblum, the method I was using to generate newlines by ending lines with backslashes apparently isn't supported by our website template. That was causing the Documents sections of the pages look weird. So I regenerated all of the pages to explicitly add break tags at the end of the lines instead. I think that should fix the problem.