### PR TITLE
new instructions for authors file

### DIFF
--- a/content/pages/conferences/2022/instructions-for-abstract-submission/index.md
+++ b/content/pages/conferences/2022/instructions-for-abstract-submission/index.md
@@ -1,0 +1,118 @@
+---
+title: Instructions for Abstract Submission
+summary: For presentations at TDWG 2022, to be published in _Biodiversity Information Science and Standards_
+cover_image: https://images.unsplash.com/photo-1579873542903-b9064ba3c9ad?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2550&q=80
+cover_image_by: Dave Hoefler
+cover_image_ref: https://unsplash.com/photos/DVauUHIJby0
+tags: conference
+status: hidden
+page_order: 65
+---
+
+# Instructions for Abstract Submission
+
+_Last updated 19 August 2021_
+
+1. You will be using Pensoft’s ARPHA online publishing platform to submit your abstract to TDWG 2021 through the online editor ([ARPHA](https://arpha.pensoft.net/)) to the journal, _[Biodiversity Information Science and Standards](https://biss.pensoft.net/) (BISS)_. The deadline for submission of abstracts was 2 August 2021 (now passed). **The deadline has been extended to 20 August 2021 for POSTER abstract submissions only** (see #10 below). See also [expectations of poster presentations](https://www.tdwg.org/conferences/2021/presentation-info/#posters).
+2. The theme of the conference is _Connecting the world of biodiversity data: standards uniting people, processes, and tools._  
+3. Your abstract will be peer reviewed and submission implies registration for and participation in the TDWG 2021 virtual conference to present its content (live or pre-recorded).  
+4. The Program Committee reserves the right to schedule accepted abstracts to fit space and time constraints, as well as the right to limit the number of oral presentations by any single presenting author. Abstracts will be published with digital object identifiers (DOIs) upon acceptance and after any registration fees have been paid.
+5. **To submit your abstract, log in or register** at [https://biss.pensoft.net/](https://biss.pensoft.net/). You will need to acknowledge [Terms of Use](https://biss.pensoft.net/about#TermsofUse) if you are new to the system. While links in emails from pensoft.net should no longer automatically log you in without an intervening Captcha step, **please whitelist or otherwise train your email system to recognize these vital communications**.
+6. **If you are starting a new abstract**, click the “Start TDWG 2021 Conference Abstract” button, which should be visible after signing in at [https://biss.pensoft.net](https://biss.pensoft.net). Clicking this button takes you to the ARPHA writing tool and creates a _new_ Untitled abstract with some of the author metadata you used to create your account. _This is the easiest way to start a NEW abstract._
+7. **If you have already started an abstract** and are coming back to work on it (will show as Draft), log in to ARPHA directly from [https://arpha.pensoft.net](https://arpha.pensoft.net). After logging in you will see the titles of “My recent manuscripts.” Click on your manuscript title, or click on “See More” to go to your dashboard [https://arpha.pensoft.net/dashboard.php](https://arpha.pensoft.net/dashboard.php), where you will see all manuscripts on which you are listed as an author, their status, and revision history. If you accidentally create more than one abstract, you need to delete the extra one(s) here. You can also start new abstracts here, but you will need to specify the journal (_BISS_) and the manuscript type (conference abstract).
+8. **Click “Collections” on the top navigation bar of your manuscript** (top right of figure below). The Collections constitute the themes of the conference. This step is critical as your abstract cannot be directed to the proper editors without this designation. Note that both authors and editors have the ability to [designate a collection](https://arpha.pensoft.net/tips/Add-to-Article-Collections) _but only_ when they have control of the manuscript.
+![Collections Banner Icon](https://static.tdwg.org/conferences/2020/instructions/2_CollectionsBannerIcon.png "Collections Banner Icon") <br /> <br />
+Find the most appropriate collection for your abstract. For an explanation about available collections (some are not accepting unsolicited abstracts), please see the [Session List](../session-list/). <br /> <br />
+![Collections List](https://static.tdwg.org/conferences/2021/images/tdwg2021-biss-collections.png "Collections List") <br /> <br />
+9. Next, **fill in your abstract’s metadata** from the list at the left by hovering over a category, and then clicking on the pencil icon.
+    1. The only mandatory fields are “Title”, “Author”, “Abstract”, “Keywords”, “Presenting Author” and “Presented At” (should be filled in with “TDWG 2021” and only that).
+    2. **Title format:** all major words should begin with a capital letter (Title Case), with only the first word capitalized after a colon, unless it is a proper noun, (e.g., Title of Awesome Talk: Why are we here in Alexandria?). _Please do not use all uppercase or inappropriate italics in your title._
+    3. **Authors:**
+        1. The **_submitting author_** is the person who will ultimately be responsible _and available_ to submit your abstract to the journal for publication, which will also submit your abstract to the conference. This is automatically assumed to be the person first logging in and starting the abstract in ARPHA and that person's name is assumed to be first author. This can be [changed](https://arpha.pensoft.net/tips/Edit-author-order-details).
+        2. **_[Add co-authors](https://arpha.pensoft.net/tips/Add-authors)_** by clicking the icon beside “Authors” in the left-side navigation panel. Be sure to add affiliations for all authors. **_When adding co-authors, please specify what rights each will have to comment only or to edit and comment_**. Note that it is the _submitting_ author's responsibility to notify all authors of this submission and their rights with regard to commenting or editing.
+        3. Make sure that one author is designated as the **_corresponding author_** (the person to whom correspondence should be addressed _after_ publication). May be any author.
+        4. The **_Presenting Author_** (added outside of Authors metadata panel, after Keywords) is the person who will be delivering the presentation at the conference. List their name in the same way it is listed as an author. _The presenting author will be responsible for a live, recorded, or poster presentation and must be fully registered for the conference by the time the abstract is approved for publication._
+    4. **Abstract** submissions are limited to 6,000 characters (including spaces, title, authors and affiliations, keywords, references, etc.), written in English, and should be appropriate to the conference theme, _Connecting the world of biodiversity data: standards uniting people, processes, and tools_. 
+        1. Please write for a general audience, providing context for your presentation and no unexplained jargon. _Note that this is not a venue for reporting the results of research in your discipline._
+        2. The first mention of acronyms (including organizational acronyms) or abbreviations in the abstract or figure/table legends must be spelled out (exceptions: 3D, DNA, RNA, GIS, HTML, WWW, URL, URI, XML, RDF, JPG, TIF, TIFF, PDF).
+        3. Consider [embedding hyperlinks](https://arpha.pensoft.net/tips/Insert-Hyperlinks) (URLs) to institutions and concepts that will help readers to appreciate more fully the topic you are presenting. This can be especially helpful for jargon. Be mindful of persistence (not having future users find broken links) and irrelevant advertising if you choose to do this.
+        4. You may add [references](https://arpha.pensoft.net/tips/References), [figures](https://arpha.pensoft.net/tips/Figures), [tables](https://arpha.pensoft.net/tips/Tables) and upload [supplementary materials](https://arpha.pensoft.net/tips/Supplementary-files) associated with the abstract. None of these are required. Create these resources first from the end of the left menu, [before linking them to the appropriate text](https://arpha.pensoft.net/tips/Cite-references) in your abstract.
+    5. **Keywords:** are words that readers might use in a search to find your content
+        1. Please add keywords not used in the title of the abstract
+        2. Separate each keyword by a comma (not a semicolon)
+        3. Only capitalize proper nouns; do not capitalize the first keyword unnecessarily
+    6. **_Please proofread your submission carefully._** 
+    7. **Validate:** Click this button (near bottom of left panel) to have the system automatically ensure that mandatory fields are filled in, you have not exceeded the 6,000 character limit, and the abstract is assigned to a collection. Be sure to finish this step, even if you and your co-authors are not finished writing or reviewing your submission.
+10. **Submit for Technical Review:** <a id="submit-for-technical-review"></a>Clicking this button (bottom of the left panel) is the first step toward submitting your abstract for consideration as part of the virtual conference. **This is the step that must be completed by the deadline** (extended for POSTERS ONLY to 20 August).
+    1. You should receive an auto-generated confirmation email (be sure to find this in your email). 
+    2. On your ARPHA dashboard, the status of the manuscript will change to _in pre-submission review_ and will be in read-only mode for authors.
+    3. You may see the work of various technical editors suggesting changes to be made or making comments on your abstract, but you will only be able to view, not edit your submission while it is in pre-submission review. Wait until you receive official notice that feedback has been requested—do not ask technical editors to make changes.
+11. **Feedback from Editors and Revisions:** The organizers (technical editors) may accept or reject your submission, or may send feedback requesting changes, and/or indicate that your abstract is being moved to a different collection or format (e.g., oral to poster) for programming reasons. 
+    1. **_Draft_** (again): if a submission is returned to you for changes, its status will return to _Draft_. Only you and other authors with editing or commenting privileges will have access to the abstract until you make or respond to changes requested and send it back for technical review. 
+    2. **_[Track Changes](https://arpha.pensoft.net/tips/Track-Changes)_** and/or written comments from editors need to be addressed. Accept or reject suggestions and use comments as necessary to further communicate your actions.
+    3. Your manuscript may require more than one cycle of revision so please address communications promptly. 
+12. **Approved!! Now finalize and submit your abstract.** 
+    1. **_Double check the presenting author_** (should only be the name as listed as an author) and do a final proofing of your abstract.
+    2. **_Validate._** Next, click the validate button first to make sure there are no lingering issues. See [https://arpha.pensoft.net/tips/Finalise-a-Manuscript](https://arpha.pensoft.net/tips/Finalise-a-Manuscript). Click on the blue text for each issue to resolve it. A successful validation will only show the number of characters in your abstract. 
+    3. Once approved, the ‘**_Submit to the journal_**’ button should become visible (if you do not see this button, you may not be listed as the submitting author see #9.3.i above) in the ARPHA Writing Tool. When you are ready to submit your abstract for publication, click the ‘Submit to the journal’ button and then go through the (long) checklist of submission steps.
+    4. The first step in the checklist regards the **_license and copyright_** of your abstract. The default is [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) with copyright attributed to the authors. However, if _any_ author is a U.S. or Canadian government employee, you must specify [CC-0](https://creativecommons.org/share-your-work/public-domain/cc0/). Any other issues should be referred to the journal’s help desk.
+    5. Step 2 requires that you mark the box indicating "I am aware that my abstract will be published only after registering and payment of any fees for the TDWG 2021 conference". 
+    6. The final step asks you to **_assign categories_** (taxon, geographic area, scientific subject, geological era) to your submission; complete this step if it is applicable, but _be sure to click through to the end of the submission process_.
+    7. When the submission process is finalised, you should receive an email confirming the successful submission and the abstract goes directly to production for publication, a DOI (digital object identifier) is assigned, and the abstract cannot be revised further (without difficulty). 
+    8. At publication, you should receive a confirmation email from the journal.
+13.  **Incomplete Submission:** ( If, after your manuscript has been approved, you fail to complete all of the steps in the previous section, you may see it tagged as _Incomplete Submission_ in your ARPHA dashboard, even though a BISS ID has been assigned to it. Because this now has a BISS identifier, you must access actions to complete the submission (or delete it) via the BISS dashboard [https://biss.pensoft.net/dashboard?view_mode=1&journal_id=63](https://biss.pensoft.net/dashboard?view_mode=1&journal_id=63) not ARPHA’s. <br /> <br />
+![IncompleteSubmission](https://static.tdwg.org/conferences/2020/instructions/3_IncompleteSubmission.png "IncompleteSubmission")<br /> <br /> 
+_The deadline for finalizing your abstract for publication in the journal will **in September (TBA)**, to enable us to prepare the program._ <br /> <br />
+14. If, at any time, you need further technical assistance, check the [Tips and tricks](https://arpha.pensoft.net/tips/) link or if you fail to find an answer to your question, send an email to the journal’s technical staff via the system. Click “Feedback” icon (on the top navigation bar to open a new window with an email form for you to fill in or email [editor@tdwg.org](mailto:editor@tdwg.org). Note that icons now use tool tips (mouse over) and do not otherwise include text explanations. For content questions, please email [conf-organizers@tdwg.org](mailto:conf-organizers@tdwg.org). 
+
+
+## ARPHA-related FAQs
+
+### How does the editing process work?
+
+Your abstract will be edited and reviewed for content and suitability as well as style and language by conference and session organizers and other volunteers.  Once authors submit an abstract, the collection editors are notified about it, and they gain access to it. Once they evaluate it, and leave notes for its improvement (if any), they send feedback to the authors. At that point you—as the Submitting author—receive an automated notification from awt@pensoft.net, with access in editing mode to the abstract. After you coordinate the modifications with your coauthors, you can resubmit. This cycle can be reiterated as many times as needed, until the abstract is accepted, and ready to be submitted to the journal (to be published as is). Please wait for the system notification.
+If, for some reason, your abstract is not accepted by the conference organizers under the collection (e.g., symposium) to which you submitted it, they will notify [editor@tdwg.org](mailto:editor@tdwg.org) for help in moving it elsewhere, if possible.
+
+### I see feedback and corrections to make in my abstract, but I don't have access. Did I do something wrong?
+
+Don't worry--you did nothing wrong. Your abstract is still undergoing review (status should be in pre-submission review; see below to "How do I know the status of my abstract") and should be sent back to you soon. If you have further questions or issues (e.g., you're going to be out of touch soon for a period of time), email the [organizers of your session](https://www.tdwg.org/conferences/2021/session-list/) so they can prioritize providing you feedback, or email [editor@tdwg.org](mailto:editor@tdwg.org).
+
+### Where do I enter the state or province under address as an author?
+
+ARPHA does not currently track that information. If you feel it is necessary, add an [ISO 3166-2 code](http://www.unece.org/cefact/locode/subdivisions.html) for your country's subdivision, separating it from the city name with a comma and space.
+
+### My abstract has been approved and it validates but why don’t I see a “submit to journal” button?
+
+You may not be the person who originally submitted the abstract. To check this, open the Authors metadata (top left choice) to Manage Authors and make sure that despite the fact that you may be “Corresponding Author” that “Make submitting author” is not an option to be chosen next to your name _(note that currently this is not working; efforts are being made to restore this function)_. If it is (and one of your co-authors does not have this), click on the button to make you the submitting author, save the changes, and see if you now can submit the abstract to the journal. You may need to log out of ARPHA and/or your browser to have changes made reflect properly when you log back in. Still have issues? Please contact the help desk.
+
+### I use more than one email for my work. How do I choose one?
+
+In the ARPHA editorial platform, you should use only one email account that you check regularly, will have persistence, and that you do not mind being public (the system displays it publicly to other users and in published papers). This way all tasks appointed to the user will be accumulated under a single account and you will not have to log in and out and access several dashboards for a single journal. The editorial platform allows users to have different roles within the same journal and also in other journals hosted by Pensoft. The system does not allow adding more than one email per account and is not set to enable sending a copy of the same notification to an alternative email of the same user. If you have been asked to merge two or more accounts into a single one, Pensoft will need to choose one of the emails as primary. This is also used to send alerts and newsletters of Pensoft journal content to which you may subscribe.
+
+Regardless of email, if you are an author and need to credit a particular institution for the work you are presenting, modify your affiliation in the author metadata for each abstract or manuscript submitted.
+
+### How do I know the status of my abstract?
+
+Sign into [ARPHA](https://arpha.pensoft.net/). Your abstract(s) should be listed under the My Manuscripts tab (text will be gray) on your dashboard. On the right of each manuscript, you can see the status. Note that only one person can work on an abstract at a time (either as authors or editors). If you are not actively working on a manuscript, please close the window to give others a chance to contribute. _Note:_ the dashboard may give misleading indications that someone is editing the manuscript. You can verify if this is true by clicking on the manuscript title.
+
+
+
+*   **_Draft_** = authors have editing rights; editors see as read-only; authors must submit the abstract for review for the abstract to be released for editorial assessment.
+*   **_In pre-submission review_** = authors see as read-only; technical editors are able to make changes to the abstract and add comments. Authors may see these updates but will not be able to make changes until editors release the abstract back to the authors using the Send Feedback button. Pressing the Send Feedback button returns the abstract to Draft mode so that authors may respond.
+*   Once your abstract has been **_Approved_**, the submitting author will need to **_Submit to Journal_** and complete the final publication checklist (this consists of multiple screens; please be sure to follow it to the end). It then proceeds to **_Layout_** and is in a queue to be **_Published_**. **The final deadline for submission to the journal will be determined.** Make sure that the submitting author will be available until the process is complete.
+*   If you fail to complete the final publication checklist, your abstract may be marked as **_Incomplete Submission_**. You will get three automated warnings to remedy this before the system automatically buries/removes your submission from the publication queue.
+*   Both authors and technical editors can send email (see icon near the top of the page) to co-authors and/or editors at any time during the pre-approval process, _this does not change the status of the manuscript. _If you use this step, please fully reference your manuscript ID, the issue(s) and the person(s) you think should be responding to the email. The system sends individual emails out so no one receiving them knows who else is being asked to address your question. If in doubt, email [editor@tdwg.org](mailto:editor@tdwg.org) outside of the system instead.
+*   For an abstract associated with TDWG 2021 to be published, the presenter must be fully registered (i.e., any assessed fee paid) for the conference.
+*   Approved abstracts will be published once the placement of their presentation in the program is confirmed. Authors should receive notification of successful submission to the journal, pending publication. 
+
+### What if I don’t see my abstract anywhere?
+
+It is possible that you have more than one ARPHA account under different emails. Please consolidate them if this is the case.
+
+Another possibility is that the ARPHA platform has automatically archived your abstract due to prolonged inactivity (does so after three ignored email warnings). You will need to notify Pensoft to retrieve such an abstract from this fate. Please make sure all communications include an article identifier (ID#) in the subject line. When it is returned, it will be in Draft mode and you will need to need to start at #10 in this document. Editors are not be able to work on or accept a manuscript in Draft status.
+
+Otherwise, communicate with the help desk (use the feedback icon located in the top banner of your abstract) to try to resolve technical issues or with [editor@tdwg.org](mailto:editor@tdwg.org) or [conf-organizers@tdwg.org](mailto:conf-organizers@tdwg.org) for content/meeting-related questions.
+
+### Where will I find published abstracts?
+
+See [published abstract collections](https://biss.pensoft.net/collections) or find [_TDWG Proceedings 2021_](https://biss.pensoft.net/collection/293/). Sign up for [email notifications](https://pensoft.net/profile/alerts/edit) of newly published content from _[Biodiversity Information Science and Standards](https://pensoft.net/) (BISS)_ after signing in.


### PR DESCRIPTION
This should stay **hidden** while it's being restructured, and until we are ready to announce the call for abstracts.