### PR TITLE
make various corrections to match current document headers

### DIFF
--- a/content/pages/standards/ac/index.md
+++ b/content/pages/standards/ac/index.md
@@ -60,23 +60,24 @@ Documents:
 **Title:** Audubon Core Term List <br/>
 **Permanent IRI:** [http://rs.tdwg.org/ac/doc/termlist/](https://tdwg.github.io/ac/termlist/) <br/>
 **Created:** 2013-10-23 <br/>
-**Last modified:** 2021-02-01 <br/>
+**Last modified:** 2021-10-05 <br/>
 **Contributors:** <br/>
 Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
+Annette Olson (author) - American Association for the Advancement of Science <br/>
+Steve Baskauf (author) - Audubon Core Maintenance Group <br/>
 Vijay Barve (author) <br/>
 Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark <br/>
 Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
 José Cuadra (author) <br/>
 Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA <br/>
-Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
 Patrick Leary (author) <br/>
 Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
-Annette Olson (author) - American Association for the Advancement of Science <br/>
 Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
 Ivan Teage (author) <br/>
-Steve Baskauf (author) - Audubon Core Maintenance Group <br/>
 Dan Stowell (author) - Queen Mary University of London <br/>
 Edward Baker (author) - Natural History Museum, London <br/>
+Richard Pyle (author) - Bishop Museum, Honolulu, HI, USA <br/>
 Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
 **Publisher:** Biodiversity Information Standards (TDWG) <br/>
 **Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. It aims to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains a list of attributes of each Audubon Core term, including a documentation name, a specified URI, a recommended English label for user interfaces, a definition, and some ancillary notes. The version shown here was adopted by Biodiversity Information Standards / TDWG at the general meeting in October 2013 and updated in 2021. This document contains normative content that may not be changed without due process. <br/>
@@ -85,7 +86,7 @@ Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
 **Title:** Audubon Core Structure <br/>
 **Permanent IRI:** [http://rs.tdwg.org/ac/doc/structure/](https://tdwg.github.io/ac/structure/) <br/>
 **Created:** 2013-10-23 <br/>
-**Last modified:** 2020-01-27 <br/>
+**Last modified:** 2021-10-05 <br/>
 **Contributors:** <br/>
 Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
 Vijay Barve (author) <br/>
@@ -99,6 +100,7 @@ Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
 Annette Olson (author) - American Association for the Advancement of Science <br/>
 Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
 Ivan Teage (author) <br/>
+Steve Baskauf (author) - Vanderbilt University, Nashville, TN, USA <br/>
 Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
 **Publisher:** Biodiversity Information Standards (TDWG) <br/>
 **Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains material introductory to the Audubon Core Term List. <br/>
@@ -131,15 +133,18 @@ Steve Baskauf (review manager) - Vanderbilt University, Nashville, TN, USA <br/>
 **Created:** 2013-10-15 <br/>
 **Last modified:** 2013-10-15 <br/>
 **Contributors:** <br/>
+Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Vijay Barve (author) <br/>
 Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark <br/>
 Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+José Cuadra (author) <br/>
 Chris Freeland (author) - Missouri Botanical Garden, St. Louis, USA <br/>
 Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany <br/>
-Robert A. Morris (lead author) - University of Massachusetts at Boston, USA <br/>
+Patrick Leary (author) <br/>
 Dimitry Mozzherin (author) - Encyclopedia of Life, Woods Hole, USA <br/>
 Annette Olson (author) - American Association for the Advancement of Science <br/>
 Greg Riccardi (author) - Florida State University, Tallahassee, USA <br/>
-Éamonn Ó Tuama (author) - Global Biodiversity Information Facility, Copenhagen, Denmark <br/>
+Ivan Teage (author) <br/>
 **Publisher:** Biodiversity Information Standards (TDWG) <br/>
 **Abstract:** The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. This non-normative document provides some background to the aims and uses of the standard. <br/>
 **Citation:** Multimedia Resources Task Group. 2013. Audubon Core Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/guide/
@@ -172,8 +177,8 @@ Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries <br/>
 **Last modified:** 2020-10-13 <br/>
 **Contributors:** <br/>
 Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries <br/>
+Ed Baker (contributor) - Natural History Museum, London <br/>
 Dan Stowell (contributor) - Queen Mary University of London <br/>
-Edward Baker (contributor) - Natural History Museum, London <br/>
 **Publisher:** Biodiversity Information Standards (TDWG) <br/>
 **Abstract:** Audubon Core uses the terms ac:variant and ac:variantLiteral to provide information about the size, extent, and availability of the Service Access Point of a media item. This controlled vocabulary provides values for those terms. <br/>
 **Citation:** Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core variant: List of Terms. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/ac/doc/variant/2020-10-13

--- a/content/pages/standards/delta/index.md
+++ b/content/pages/standards/delta/index.md
@@ -47,8 +47,8 @@ Documents:
 **Created:** 2005-09-13 <br/>
 **Last modified:** 2005-09-13 <br/>
 **Contributors:** <br/>
-Michael J. Dallwitz (author) <br/>
-Toni Anne Paine (author) <br/>
+M. J. (Michael J.) Dallwitz (author) <br/>
+T. A. (Toni Anne) Paine (author) <br/>
 **Publisher:** Commonwealth Scientific and Industrial Research Organisation (CSIRO) <br/>
 **Abstract:** This document is primarily for the benefit of programmers, and contains more detail than would usually be required by users of the DELTA format. It provides an introduction to the format, and details necessary to encode data in the format. <br/>
 **Note:** See http://delta-intkey.com/www/overview.htm for an overview and http://delta-intkey.com/www/use.htm for conditions of use. <br/>

--- a/content/pages/standards/dwc/index.md
+++ b/content/pages/standards/dwc/index.md
@@ -110,13 +110,14 @@ Mark Schildhauer  (author) - National Center for Ecological Analysis and Synthes
 **Title:** Darwin Core Text Guide <br/>
 **Permanent IRI:** [http://rs.tdwg.org/dwc/terms/guides/text/](https://dwc.tdwg.org/text/) <br/>
 **Created:** 2014-11-08 <br/>
-**Last modified:** 2014-11-08 <br/>
+**Last modified:** 2021-07-15 <br/>
 **Contributors:** <br/>
 Tim Robertson (lead author) - Global Biodiversity Information Facility <br/>
 Markus Döring (author) - Global Biodiversity Information Facility <br/>
-John Wieczorek (author) - TDWG Darwin Core Task Group <br/>
+John Wieczorek (author) - Darwin Core Maintenance Group <br/>
 Renato De Giovanni (author) - Centro de Referência em Informação Ambiental <br/>
 Dave Vieglais (author) - KU Natural History Museum <br/>
+Steve Baskauf (author) - Darwin Core Maintenance Group <br/>
 Gail E. Kampmeier (review manager) - University of Illinois at Urbana-Champaign <br/>
 **Publisher:** Biodiversity Information Standards (TDWG) <br/>
 **Abstract:** This document provides guidelines for implementing Darwin Core in Text files. <br/>
@@ -183,7 +184,7 @@ David Bloom (contributor) - VertNet <br/>
 Paula Zermoglio (contributor) - VertNet <br/>
 Robert Guralnick (contributor) - University of Florida <br/>
 John Deck (contributor) - Genomic Biodiversity Working Group <br/>
-Gail Kampmeier (review manager) - Illinois Natural History Survey <br/>
+Gail Kampmeier (contributor) - Illinois Natural History Survey <br/>
 Dave Vieglais (contributor) - KU Natural History Museum <br/>
 Renato De Giovanni (contributor) - Centro de Referência em Informação Ambiental <br/>
 Campbell Webb (contributor) - TDWG RDF/OWL Task Group <br/>
@@ -196,7 +197,7 @@ Mark Schildhauer (contributor) - National Center for Ecological Analysis and Syn
 **Title:** Degree of Establishment Controlled Vocabulary List of Terms <br/>
 **Permanent IRI:** [http://rs.tdwg.org/dwc/doc/doe/](https://dwc.tdwg.org/doe/) <br/>
 **Created:** 2020-10-13 <br/>
-**Last modified:** 2020-10-13 <br/>
+**Last modified:** 2021-09-01 <br/>
 **Contributors:** <br/>
 Quentin Groom (lead author) - Botanic Garden Meise <br/>
 Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
@@ -204,7 +205,7 @@ Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <b
 Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
 Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
 Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform <br/>
-Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Steven J Baskauf (contributor) - Vanderbilt University Libraries <br/>
 Arthur Chapman (contributor) - Australian Biodiversity Information Services <br/>
 Melodie McGeoch (contributor) - McGeoch Research Group <br/>
 Ramona Walls (contributor) - University of Arizona <br/>
@@ -219,7 +220,7 @@ Annie Simpson (contributor) - U.S. Geological Survey <br/>
 **Title:** Establishment Means Controlled Vocabulary List of Terms <br/>
 **Permanent IRI:** [http://rs.tdwg.org/dwc/doc/em/](https://dwc.tdwg.org/em/) <br/>
 **Created:** 2020-10-13 <br/>
-**Last modified:** 2020-10-13 <br/>
+**Last modified:** 2021-09-01 <br/>
 **Contributors:** <br/>
 Quentin Groom (lead author) - Botanic Garden Meise <br/>
 Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
@@ -227,7 +228,7 @@ Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <b
 Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
 Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
 Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform <br/>
-Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Steven J Baskauf (contributor) - Vanderbilt University Libraries <br/>
 Arthur Chapman (contributor) - Australian Biodiversity Information Services <br/>
 Melodie McGeoch (contributor) - McGeoch Research Group <br/>
 Ramona Walls (contributor) - University of Arizona <br/>
@@ -242,7 +243,7 @@ Annie Simpson (contributor) - U.S. Geological Survey <br/>
 **Title:** Pathway Controlled Vocabulary List of Terms <br/>
 **Permanent IRI:** [http://rs.tdwg.org/dwc/doc/pw/](https://dwc.tdwg.org/pw/) <br/>
 **Created:** 2020-10-13 <br/>
-**Last modified:** 2020-10-13 <br/>
+**Last modified:** 2021-09-01 <br/>
 **Contributors:** <br/>
 Quentin Groom (lead author) - Botanic Garden Meise <br/>
 Peter Desmet (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
@@ -250,7 +251,7 @@ Lien Reyserhove (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <b
 Tim Adriaens (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
 Damiano Oldoni (contributor) - Instituut voor Natuur- en Bosonderzoek (INBO) <br/>
 Sonia Vanderhoeven (contributor) - Belgian Biodiversity Platform <br/>
-Steve Baskauf (contributor) - Vanderbilt University Libraries <br/>
+Steven J Baskauf (contributor) - Vanderbilt University Libraries <br/>
 Arthur Chapman (contributor) - Australian Biodiversity Information Services <br/>
 Melodie McGeoch (contributor) - McGeoch Research Group <br/>
 Ramona Walls (contributor) - University of Arizona <br/>

--- a/content/pages/standards/guid-as/index.md
+++ b/content/pages/standards/guid-as/index.md
@@ -56,7 +56,7 @@ Ben Richardson (review manager) - Department of Environment and Conservation, We
 **Created:** 2009-09-03 <br/>
 **Last modified:** 2009-09-03 <br/>
 **Contributors:** <br/>
-Ricardo Scachetti-Pereira (author) - TDWG Infrastructure Project <br/>
+Ricardo Pereira (author) - TDWG Infrastructure Project <br/>
 Kevin Richards (author) - Landcare Research <br/>
 Donald Hobern (author) - Global Biodiversity Information Facility <br/>
 Roger Hyam (author) - TDWG Infrastructure Project <br/>

--- a/content/pages/standards/tcs/index.md
+++ b/content/pages/standards/tcs/index.md
@@ -48,8 +48,8 @@ Documents:
 **Created:** 2006-09-21 <br/>
 **Last modified:** 2006-09-21 <br/>
 **Contributors:** <br/>
-Jessie Kennedy (author) - Napier University  <br/>
 Roger Hyam (author) - TDWG Infrastructure Project <br/>
+Jessie Kennedy (editor) - Napier University  <br/>
 **Publisher:** Biodiversity Information Standards (TDWG) <br/>
 **Abstract:** This guide is meant to act as a readable introduction to the Taxon Concept Schema (TCS). It is aimed at both decision makers and implementers of systems and so the content varies from being of a general nature, assuming little prior knowledge of taxonomy or XML technologies, to being quite detailed concerning the technicalities of biological nomenclature and XML schemas. Generally it becomes more specific as it goes on. This document is not a step by step manual for mapping a data source to a TCS document. Each data source is likely to be different in structure and so this is not a feasible exercise. What it attempts to do is provided the information needed for an implementer to make intelligent decisions as to how their data source should be mapped to the schema so that they can publish and/or receive data from other systems with as little confusion as possible.  <br/>
 **Citation:** Taxonomic Names Subgroup. 2006. Taxon Concept Schema User Guide. Biodiversity Information Standards (TDWG). http://rs.tdwg.org/tcs/doc/guide/

--- a/content/pages/standards/vms/index.md
+++ b/content/pages/standards/vms/index.md
@@ -55,7 +55,7 @@ Documents:
 **Contributors:** <br/>
 Steve Baskauf (lead author) - TDWG Vocabulary Maintenance Specification Task Group <br/>
 John Wieczorek (author) - TDWG Darwin Core Task Group <br/>
-Stanley Blum (author) - TDWG Process Interest Group <br/>
+Stan Blum (author) - TDWG Process Interest Group <br/>
 Robert A. Morris (author) - UMASS-Boston, TDWG Imaging Interest Group <br/>
 Jonathan Rees (author) - Duke University <br/>
 Joel Sachs (author) - TDWG RDF Task Group <br/>


### PR DESCRIPTION
I did a thorough comparison of how authors are listed in the current versions of documents and made a lot of corrections in the form of names, order listed, roles, etc. There were also some cases where the most recent update date was not correct.