### PR TITLE
Update page for XDF and link to the specification PDF now in the TDWG GitHub repo

### DIFF
--- a/content/pages/standards/xdf/index.md
+++ b/content/pages/standards/xdf/index.md
@@ -29,7 +29,7 @@ Bibliographic citation
 
 ## Parts of the standard
 
-This standard is comprised of one document. 
+This standard is comprised of two documents. 
 
 Documents:
 
@@ -40,8 +40,18 @@ Documents:
 **Contributors:** <br/>
 Richard J. White (author) <br/>
 Robert Allkin (author) <br/>
-**Publisher:** IUBS Commission for Plant Taxonomic Databases (TDWG) <br/>
+**Publisher:** Elsevier <br/>
 **Abstract:** XDF (the Exchange Data Format) is a database file exchange medium to handle diverse classes of biological data required for file transfers between different database projects. Data sets prepared in XDF consists of text files that are effectively independent of any particular project. XDF is a high-level language for describing biological data, with its own syntax and command vocabulary, analogous to the high-level programming languages used to describe software algorithms.  <br/>
-**Note:** Note: the article linked to the access uri does not seem to be the actual standard itself.  See reference number 16 in the article. <br/>
-**Citation:** TDWG XDF Subgroup (Authors: R. J. White and R. Allkin). 1992. XDF: A Language for the Definition and Exchange of Biological Data Sets. IUBS Commission for Plant Taxonomic Databases (TDWG). http://rs.tdwg.org/xdf/doc/article/
+**Citation:** White, Richard J. and Robert Allkin. 1992. XDF: A Language for the Definition and Exchange of Biological Data Sets. Mathematical and Computer Modelling 16:199-223. <https://doi.org/10.1016/0895-7177(92)90163-F>
+
+**Title:** XDF: A Language for the Definition and Exchange of Biological Data Sets - Description and Manual, version 3.3<br/>
+**Permanent IRI:** [http://rs.tdwg.org/xdf/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/xdf/xdf_description_and_manual_v3.3_1989.pdf) <br/>
+**Created:** 1989-11-01 <br/>
+**Last modified:** 1989-11-01 <br/>
+**Contributors:** <br/>
+Robert Allkin (author) <br/>
+Richard J. White (author) <br/>
+**Publisher:** IUBS Commission for Plant Taxonomic Databases (TDWG) <br/>
+**Abstract:** XDF (the Exchange Data Format) is a medium for the exchange of diverse classes of biological data between different database projects and application programs. This document provides a detailed definition of the syntax and conventions followed in the XDF language and of the principal XDF directives. The manual is intended for biologists using XDF either to take advantage of predefined, standard transfer formats or to define their own transfer format.  <br/>
+**Citation:** Allkin, Robert and Richard J. White. 1989. XDF: A Language for the Definition and Exchange of Biological Data Sets - Description and Manual, version 3.3. IUBS Commission for Plant Taxonomic Databases (TDWG). <http://rs.tdwg.org/xdf/doc/specification/>
 

--- a/content/pages/standards/xdf/index.md
+++ b/content/pages/standards/xdf/index.md
@@ -46,8 +46,8 @@ Robert Allkin (author) <br/>
 
 **Title:** XDF: A Language for the Definition and Exchange of Biological Data Sets - Description and Manual, version 3.3<br/>
 **Permanent IRI:** [http://rs.tdwg.org/xdf/doc/specification/](https://github.com/tdwg/prior-standards/blob/master/xdf/xdf_description_and_manual_v3.3_1989.pdf) <br/>
-**Created:** 1989-11-01 <br/>
-**Last modified:** 1989-11-01 <br/>
+**Created:** 1989-11-02 <br/>
+**Last modified:** 1989-11-02 <br/>
 **Contributors:** <br/>
 Robert Allkin (author) <br/>
 Richard J. White (author) <br/>


### PR DESCRIPTION
Paco Pando found a copy of the XDF specification! He scanned it and made a PDF of it, and it is now in the Prior Standards repo. This pull request updates the standards landing page so that it links to the specification document.