### PR TITLE
corrected link to template for anual report

### DIFF
--- a/content/pages/community/management/index.md
+++ b/content/pages/community/management/index.md
@@ -26,7 +26,7 @@ page_order:
     1. TDWG standards are developed by consensus (URL), so ensure you develop skills to foster consensus.
     2. Task Group Conveners should seek advice from the TAG to ensure that strategies are consistent with TDWG's overall approach to interoperability.
 6. Prepare annual report and brief presentations for the annual conference
-    1. An annual report is required from every Interest and Task Group. A [guide](./guide-to-reporting/) and [template](http://old.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/InterestTaskGroupAnnualReport-Template--COPYTHISDOC.docx) for reports are available. 
+    1. An annual report is required from every Interest and Task Group. A [guide](./guide-to-reporting/) and template (as [GoogleDoc](http://drive.google.com/open?id=1VYHouWmgh94zUibFgDlTW_6cwCTsYbl6Kq9vsczFPjA) or [Markdown](annual-report-template)) for reports are available. 
     2. A [PowerPoint template](http://old.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/Template_Conveners_Opening_Report.ppt) is provided for Interest and Task Group Conveners to provide a 5-minute report on the year's activities. 
     3. A [PowerPoint template](http://old.tdwg.org/activities/convener-responsibilities/fileadmin/documentation/doc_templates/Template_Conveners_Closing_Report.ppt) is provided for Interest Group and Task Conveners to provide a 5-minute report on issues for the year ahead.
 7. The TDWG Standards Process


### PR DESCRIPTION
the link still pointed to the old.tdwg.org subdomain which couldn't resolve. The single link is now replaced with links to both the Google Doc template and the markdown template, just as it is written on https://www.tdwg.org/community/management/guide-to-reporting/