### PR TITLE
Add link to hosted SDD document as website

### DIFF
--- a/standards/sdd/index.md
+++ b/standards/sdd/index.md
@@ -7,6 +7,7 @@ background:
   by: Biodiversity Heritage Library
   href: https://www.flickr.com/photos/biodivlibrary/32317503938
 github: https://github.com/tdwg/sdd
+website: https://tdwg.github.io/sdd/SddContents.html
 toc: true
 ---
 


### PR DESCRIPTION
@stanblum, this is a follow-up of https://github.com/tdwg/sdd/pull/5#issuecomment-1416875440, where you mentioned:

> In the meantime, I think I'll make the simplest edits on the SDD GitHub landing page so that the Intro/Primer is easily accessible.

If forgot to mention yesterday that you can include a `website` and `github` in the frontmatter, which will show up as buttons in the header, e.g.

<img width="884" alt="Screenshot 2023-02-07 at 09 07 22" src="https://user-images.githubusercontent.com/600993/217187462-1ae05d4a-473f-4a8d-89f3-bc86f006906c.png">

This PR adds a https://tdwg.github.io/sdd/SddContents.html as `website` button on the SDD page. I'm not sure that was your goal though. The referenced page is only one of the two documents of SDD, i.e. the "SDD Part 0: Introduction and Primer to the SDD Standard", so maybe it's better to reference that under [here](https://www.tdwg.org/standards/sdd/#introduction-and-primer-to-the-structured-descriptive-data-sdd-standard) rather than in the header.

@larsgw @baskaufs thoughts?