### PR TITLE
Add/standardize metadata on TDWG 2016, 2017, 2018, 2019 conf pages

### DIFF
--- a/conferences/2016/index.md
+++ b/conferences/2016/index.md
@@ -28,10 +28,9 @@ Programme
 Presentations
 : 37 [presentations on Vimeo](https://vimeo.com/album/4308386) as individual videos
 
-## Original conference website pages
-
-- [Main conference page](https://static.tdwg.org/conferences/2016/tdwg_2016_conference_page.pdf)
-- [About the conference](https://static.tdwg.org/conferences/2016/tdwg_2016_about_the_conference.pdf)
-- [Travel](https://static.tdwg.org/conferences/2016/tdwg_2016_travel_information.pdf)
-- [Hotels](https://static.tdwg.org/conferences/2016/tdwg_2016_hotels.pdf)
-- [Excursions](https://static.tdwg.org/conferences/2016/tdwg_2016_excursions.pdf)
+Conference website
+: [Main conference page](https://static.tdwg.org/conferences/2016/tdwg_2016_conference_page.pdf)
+: [About the conference](https://static.tdwg.org/conferences/2016/tdwg_2016_about_the_conference.pdf)
+: [Travel](https://static.tdwg.org/conferences/2016/tdwg_2016_travel_information.pdf)
+: [Hotels](https://static.tdwg.org/conferences/2016/tdwg_2016_hotels.pdf)
+: [Excursions](https://static.tdwg.org/conferences/2016/tdwg_2016_excursions.pdf)

--- a/conferences/2017/index.md
+++ b/conferences/2017/index.md
@@ -20,7 +20,7 @@ Date
 : 2-6 October 2017
 
 Proceedings
-: published in [Biodiversity Information Science and Standards](https://biss.pensoft.net/collection/25/)
+: [TDWG Proceedings 2017](https://biss.pensoft.net/collection/25/) in BISS
 
 Programme
 : [TDWG 2017 programme](https://static.tdwg.org/conferences/2017/tdwg_2017_programme.pdf)

--- a/conferences/2017/index.md
+++ b/conferences/2017/index.md
@@ -24,3 +24,6 @@ Proceedings
 
 Programme
 : [TDWG 2017 programme](https://static.tdwg.org/conferences/2017/tdwg_2017_programme.pdf)
+
+Conference website
+: <http://2017.tdwg.org>

--- a/conferences/2018/index.md
+++ b/conferences/2018/index.md
@@ -9,10 +9,25 @@ background:
 toc: false
 ---
 
-In 2018, TDWG met jointly with the Society for the Preservation of Natural History Collections ([SPNHC](https://spnhc.org/resources/33rd-annual-meeting-collections-and-data-in-an-unstable-world/)) in Dunedin, New Zealand. The meeting was hosted by the [Otago Museum](https://otagomuseum.nz/) and held on the adjacent University of Otago campus.
+The TDWG 2018 Annual Conference was organized as a joint conference with the  Society for the Preservation of Natural History Collections ([SPNHC](https://spnhc.org/resources/33rd-annual-meeting-collections-and-data-in-an-unstable-world/)).
 
-The [TDWG portion of the conference website](https://tdwg.github.io/conferences/2018/sessions/), particularly the session details, is still available. [Abstracts for individual presentations and posters](https://biss.pensoft.net/collection/62/) were published in our journal, [Biodiversity Information Science and Standards](https://biss.pensoft.net). [Abstracts for the 2018 SPNHC Conference](https://biss.pensoft.net/collection/63/) are available in BISS as a parallel collection.
+Host
+: [Otago Museum](https://otagomuseum.nz/)
+: [University of Otago](https://www.otago.ac.nz/)
 
-[SPNHC+TDWG 2018 Program (PDF, 10 MB)](https://spnhc.org/wp-content/uploads/2018/11/1537298280_2018SPNHC-Program.pdf)
+Venue
+: University of Otago campus in Dunedin, New Zealand
 
-The [full website](https://web.archive.org/web/20181221215058/http://spnhc-tdwg2018.nz/) can be viewed via the Internet Archive.
+Date
+: 25 August to 1 September 2018
+
+Proceedings
+: [TDWG Proceedings 2018](https://biss.pensoft.net/collection/62/) in BISS
+: [SPNHC Proceedings 2018](https://biss.pensoft.net/collection/63/) in BISS
+
+Programme
+: [SPNHC+TDWG 2018 Program](https://spnhc.org/wp-content/uploads/2018/11/1537298280_2018SPNHC-Program.pdf)
+
+Conference website
+: [http://spnhc-tdwg2018.nz](https://web.archive.org/web/20181221215058/http://spnhc-tdwg2018.nz/) (archived by the Internet Archive)
+: <http://2018.tdwg.org>: TDWG section of the website, including call for abstracts, instructions and sessions.

--- a/conferences/2019/index.md
+++ b/conferences/2019/index.md
@@ -1,7 +1,7 @@
 ---
 title: TDWG 2019
 description: >
-  Biodiversity Next - Leiden, The Netherlands
+  Biodiversity_Next - Leiden, The Netherlands
 background:
   img: https://images.unsplash.com/photo-1453903365100-a6504dc50f1f
   by: Alisa Anton
@@ -9,4 +9,23 @@ background:
 toc: false
 ---
 
-See the [conference website](https://biodiversitynext.org) for all information.
+The TDWG 2019 Annual Conference was organized as a joint "Biodiversity_Next" conference by [GBIF](https://www.gbif.org/), [DiSSCo](https://dissco.eu/), [iDigBio](https://www.idigbio.org/), [CETAF](https://cetaf.org/), [LifeWatch ERIC](http://www.lifewatch.eu/) and TDWG.
+
+Host
+: [Naturalis Biodiversity Center](https://www.naturalis.nl/)
+: [NLBIF](https://nlbif.nl/)
+
+Venue
+: Stadsgehoorzaal in Leiden, the Netherlands
+
+Date
+: 22-25 October 2019
+
+Proceedings
+: [Biodiversity_Next Proceedings 2019](https://biss.pensoft.net/collection/115/) in BISS
+
+Programme
+: <https://biodiversitynext.org/programme/>
+
+Conference website
+: <https://biodiversitynext.org>


### PR DESCRIPTION
- 2016: minor layout change
- 2017: add link to conf website (see #488)
- 2018: reword information to structured metadata + add link to conf website (see #488)
- 2019: add metadata

The same structure is now used for all TDWG 2006 to 2019 landing pages. From 2022 onwards, the entire conf website is hosted from tdwg.org