### PR TITLE
Update name to Audiovisual Core, add 2 documents, update versions

### DIFF
--- a/standards/ac/index.md
+++ b/standards/ac/index.md
@@ -1,20 +1,20 @@
 ---
-title: Audubon Core Multimedia Resources Metadata Schema
+title: Audiovisual Core Multimedia Resources Metadata Schema
 description: >
-  The Audubon Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
+  The Audiovisual Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
 background:
   img: https://images.unsplash.com/photo-1430990480609-2bf7c02a6b1a
   by: Mikhail Vasilyev
   href: https://unsplash.com/photos/gGC63oug3iY
 github: https://github.com/tdwg/ac
-website: https://tdwg.github.io/ac/
+website: https://ac.tdwg.org/
 toc: true
 ---
 
 ## Header section
 
 Title
-: Audubon Core Multimedia Resources Metadata Schema
+: Audiovisual Core Multimedia Resources Metadata Schema
 
 Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/638>
@@ -32,14 +32,14 @@ Category
 : [Technical specification](/standards/status-and-categories/#category)
 
 Abstract
-: The Audubon Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
+: The Audiovisual Core (AC) is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
 
 Citation
-: GBIF/TDWG Multimedia Resources Task Group. 2013. Audubon Core Multimedia Resources Metadata Schema. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/638>
+: GBIF/TDWG Multimedia Resources Task Group. 2013. Audiovisual Core Multimedia Resources Metadata Schema. Biodiversity Information Standards (TDWG) <http://www.tdwg.org/standards/638>
 
 ## Maintenance group
 
-Audubon Core is maintained by a specialized [Interest Group](/community/ac/) whose [charter](https://github.com/tdwg/ac/blob/master/audubon-core_maintenance-group_charter.md) was approved in January 2018. The functions of the Audubon Core Maintenance Group are described in detail in [Section 2 of the TDWG Vocabulary Maintenance Specification](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md#2-administration). In brief, the Maintenance Group manages vocabulary term additions and changes, and maintains the documentation that helps users to understand and apply the standard. As an Interest Group, it may establish Task Groups to accomplish broader changes to the standard.
+Audiovisual Core is maintained by a specialized [Interest Group](/community/ac/) whose [charter](https://github.com/tdwg/ac/blob/master/audubon-core_maintenance-group_charter.md) was approved in January 2018. The functions of the Audiovisual Core Maintenance Group are described in detail in [Section 2 of the TDWG Vocabulary Maintenance Specification](https://github.com/tdwg/vocab/blob/master/vms/maintenance-specification.md#2-administration). In brief, the Maintenance Group manages vocabulary term additions and changes, and maintains the documentation that helps users to understand and apply the standard. As an Interest Group, it may establish Task Groups to accomplish broader changes to the standard.
 
 The activities of the AC Maintenance Group are documented at the group's Github repository, <https://github.com/tdwg/ac>, where a current list of core members and their contact information can be found. Community participation is welcome. If you would like to participate in this group, contact the convener or one of the core members.
 
@@ -47,36 +47,38 @@ To participate in the communications of the group, "watch" the group's [Issues t
 
 ## Parts of the standard
 
-This standard is comprised of 4 vocabularies and 7 documents.
+This standard is comprised of 6 vocabularies and 9 documents.
 
 Vocabularies:
 
-- Audubon Core main vocabulary (<http://rs.tdwg.org/ac/>)
+- Audiovisual Core main vocabulary (<http://rs.tdwg.org/ac/>)
 - variant controlled vocabulary (<http://rs.tdwg.org/acvariant/>)
 - format controlled vocabulary (<http://rs.tdwg.org/format/>)
 - subtype controlled vocabulary (<http://rs.tdwg.org/acsubtype/>)
+- subjectOrientation controlled vocabulary (<http://rs.tdwg.org/acorient/>)
+- subjectPart controlled vocabulary (<http://rs.tdwg.org/acpart/>)
 
 Documents:
 
-### Audubon Core Term List
+### Audiovisual Core Term List
 
 Title
-: Audubon Core Term List
+: Audiovisual Core Term List
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/termlist/](https://tdwg.github.io/ac/termlist/)
+: <http://rs.tdwg.org/ac/doc/termlist/>
 
 Created
 : 2013-10-23
 
 Last modified
-: 2021-10-05
+: 2023-02-24
 
 Contributors
 : Robert A. Morris (lead author) - University of Massachusetts at Boston, USA
 : Gregor Hagedorn (author) - JKI, Federal Research Institute for Cultivated Plants, Berlin, Germany
 : Annette Olson (author) - American Association for the Advancement of Science
-: Steve Baskauf (author) - Audubon Core Maintenance Group
+: Steve Baskauf (author) - Audiovisual Core Maintenance Group
 : Vijay Barve (author)
 : Mihail Carausu (author) - Danish Biodiversity Information Facility (DanBIF), Copenhagen, Denmark
 : Vishwas Chavan (author) - Global Biodiversity Information Facility, Copenhagen, Denmark
@@ -95,24 +97,24 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. It aims to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains a list of attributes of each Audubon Core term, including a documentation name, a specified URI, a recommended English label for user interfaces, a definition, and some ancillary notes. The version shown here was adopted by Biodiversity Information Standards / TDWG at the general meeting in October 2013 and updated in 2021. This document contains normative content that may not be changed without due process.
+: The Audiovisual Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. It aims to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains a list of attributes of each Audiovisual Core term, including a documentation name, a specified URI, a recommended English label for user interfaces, a definition, and some ancillary notes. This document contains normative content that may not be changed without due process.
 
 Citation
-: Audubon Core Maintenance Group. 2021. Audubon Core Term List. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/termlist/2021-02-01>
+: Audiovisual Core Maintenance Group. 2023. Audiovisual Core Term List. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/termlist/2023-02-24>
 
-### Audubon Core Structure
+### Audiovisual Core Structure
 
 Title
-: Audubon Core Structure
+: Audiovisual Core Structure
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/structure/](https://tdwg.github.io/ac/structure/)
+: <http://rs.tdwg.org/ac/doc/structure/>
 
 Created
 : 2013-10-23
 
 Last modified
-: 2021-10-05
+: 2023-02-24
 
 Contributors
 : Robert A. Morris (lead author) - University of Massachusetts at Boston, USA
@@ -134,24 +136,24 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains material introductory to the Audubon Core Term List.
+: The Audiovisual Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them. This document contains material introductory to the Audiovisual Core Term List.
 
 Citation
-: Multimedia Resources Task Group. 2013. Audubon Core Structure. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/structure/>
+: Audiovisual Core Maintenance Group. 2023. Audiovisual Core Structure. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/structure/2023-02-24>
 
-### Audubon Core Introduction
+### Audiovisual Core Introduction
 
 Title
-: Audubon Core Introduction
+: Audiovisual Core Introduction
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/introduction/](https://tdwg.github.io/ac/introduction/)
+: <http://rs.tdwg.org/ac/doc/introduction/>
 
 Created
 : 2013-10-23
 
 Last modified
-: 2013-10-23
+: 2023-02-24
 
 Contributors
 : Robert A. Morris (lead author) - University of Massachusetts at Boston, USA
@@ -172,24 +174,24 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
+: The Audiovisual Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. These vocabularies aim to represent information that will help to determine whether a particular resource or collection will be fit for some particular biodiversity science application before acquiring the media. Among others, the vocabularies address such concerns as the management of the media and collections, descriptions of their content, their taxonomic, geographic, and temporal coverage, and the appropriate ways to retrieve, attribute and reproduce them.
 
 Citation
-: Multimedia Resources Task Group. 2013. Audubon Core Introduction. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/introduction/>
+: Audiovisual Core Maintenance Group. 2023. Audiovisual Core Introduction. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/introduction/2023-02-24>
 
-### Audubon Core Guide
+### Audiovisual Core Guide
 
 Title
-: Audubon Core Guide
+: Audiovisual Core Guide
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/guide/](https://tdwg.github.io/ac/guide/)
+: <http://rs.tdwg.org/ac/doc/guide/>
 
 Created
 : 2013-10-15
 
 Last modified
-: 2013-10-15
+: 2023-02-24
 
 Contributors
 : Robert A. Morris (lead author) - University of Massachusetts at Boston, USA
@@ -209,10 +211,10 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: The Audubon Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. This non-normative document provides some background to the aims and uses of the standard.
+: The Audiovisual Core is a set of vocabularies designed to represent metadata for biodiversity multimedia resources and collections. This non-normative document provides some background to the aims and uses of the standard.
 
 Citation
-: Multimedia Resources Task Group. 2013. Audubon Core Guide. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/guide/>
+: Audiovisual Core Maintenance Group. 2023. Audiovisual Core Guide. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/guide/2023-02-24>
 
 ### Controlled Vocabulary for Dublin Core format: List of Terms
 
@@ -220,13 +222,13 @@ Title
 : Controlled Vocabulary for Dublin Core format: List of Terms
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/format/](https://tdwg.github.io/ac/format/)
+: <http://rs.tdwg.org/ac/doc/format/>
 
 Created
 : 2020-10-13
 
 Last modified
-: 2020-10-13
+: 2023-02-24
 
 Contributors
 : Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries
@@ -237,24 +239,87 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: Audubon Core borrows the Dublin Core terms dc:format and dcterms:format to provide information about the physical or electronic format of a media item. This controlled vocabulary provides values for those two terms.
+: Audiovisual Core borrows the Dublin Core terms dc:format and dcterms:format to provide information about the physical or electronic format of a media item. This controlled vocabulary provides values for those two terms.
 
 Citation
-: Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Dublin Core format: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/format/2020-10-13>
+: Audiovisual Core Maintenance Group. 2023. Controlled Vocabulary for Dublin Core format: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/format/2023-02-24>
 
-### Controlled Vocabulary for Audubon Core subtype: List of Terms
+### Controlled Vocabulary for Audiovisual Core subjectOrientation: List of Terms
 
 Title
-: Controlled Vocabulary for Audubon Core subtype: List of Terms
+: Controlled Vocabulary for Audiovisual Core subjectOrientation: List of Terms
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/subtype/](https://tdwg.github.io/ac/subtype/)
+: <http://rs.tdwg.org/ac/doc/orient/>
+
+Created
+: 2023-04-26
+
+Last modified
+: 2023-04-26
+
+Contributors
+: Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries
+: Neil S. Cobb (contributor) - Merriam-Powell Center for Environmental Research, Northern Arizona University
+: Jennifer C. Girón Duque (contributor) - Natural Science Research Laboratory, Museum of Texas Tech University
+: Matthew Nielsen (contributor) - University of Oulu
+: Mervin E. Pérez (contributor) - Universidad de San Carlos de Guatemala
+: Randy Singer (contributor) - University of Michigan
+
+Publisher
+: Biodiversity Information Standards (TDWG)
+
+Abstract
+: The Audiovisual Core term `subjectOrientation` describes the viewing orientation relative to an organism or part of an organism depicted in a media item or region of interest. The `subjectOrientation` Controlled Vocabulary provides terms that should be used as values for `ac:subjectOrientation` and its literal-valued analog `ac:subjectOrientationLiteral`.
+
+Citation
+: Views Controlled Vocabularies Task Group. 2023. Controlled Vocabulary for Audiovisual Core subjectOrientation: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/orient/2023-04-26>
+
+### Controlled Vocabulary for Audiovisual Core subjectPart: List of Terms
+
+Title
+: Controlled Vocabulary for Audiovisual Core subjectPart: List of Terms
+
+Permanent IRI
+: <http://rs.tdwg.org/ac/doc/part/>
+
+Created
+: 2023-04-26
+
+Last modified
+: 2023-04-26
+
+Contributors
+: Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries
+: Neil S. Cobb (contributor) - Merriam-Powell Center for Environmental Research, Northern Arizona University
+: Jennifer C. Girón Duque (contributor) - Natural Science Research Laboratory, Museum of Texas Tech University
+: Matthew Nielsen (contributor) - University of Oulu
+: Mervin E. Pérez (contributor) - Universidad de San Carlos de Guatemala
+: Randy Singer (contributor) - University of Michigan
+: Anna M. L. Klompen (contributor) - University of Kansas
+
+Publisher
+: Biodiversity Information Standards (TDWG)
+
+Abstract
+: The Audiovisual Core term `subjectPart` describes the part of an organism morphology, behaviour, environment depicted in a media item or region of interest. The `subjectPart` Controlled Vocabulary provides terms that should be used as values for `ac:subjectPart` and its literal-valued analog `ac:subjectPartLiteral`.
+
+Citation
+: Views Controlled Vocabularies Task Group. 2023. Controlled Vocabulary for Audiovisual Core subjectPart: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/part/2023-04-26>
+
+### Controlled Vocabulary for Audiovisual Core subtype: List of Terms
+
+Title
+: Controlled Vocabulary for Audiovisual Core subtype: List of Terms
+
+Permanent IRI
+: <http://rs.tdwg.org/ac/doc/subtype/>
 
 Created
 : 2020-10-13
 
 Last modified
-: 2020-10-13
+: 2023-02-24
 
 Contributors
 : Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries
@@ -263,24 +328,24 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: Audubon Core uses the terms ac:subtype and ac:subtypeLiteral to refine the type of a media item to a level more specific than the Dublin Core Type Vocabulary, <http://purl.org/dc/dcmitype/>. This controlled vocabulary provides values for ac:subtype and ac:subtypeLiteral.
+: Audiovisual Core uses the terms ac:subtype and ac:subtypeLiteral to refine the type of a media item to a level more specific than the Dublin Core Type Vocabulary, <http://purl.org/dc/dcmitype/>. This controlled vocabulary provides values for ac:subtype and ac:subtypeLiteral.
 
 Citation
-: Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core subtype: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/subtype/2020-10-13>
+: Audiovisual Core Maintenance Group. 2023. Controlled Vocabulary for Audiovisual Core subtype: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/subtype/2023-02-24>
 
-### Controlled Vocabulary for Audubon Core variant: List of Terms
+### Controlled Vocabulary for Audiovisual Core variant: List of Terms
 
 Title
-: Controlled Vocabulary for Audubon Core variant: List of Terms
+: Controlled Vocabulary for Audiovisual Core variant: List of Terms
 
 Permanent IRI
-: [http://rs.tdwg.org/ac/doc/variant/](https://tdwg.github.io/ac/variant/)
+: <http://rs.tdwg.org/ac/doc/variant/>
 
 Created
 : 2020-10-13
 
 Last modified
-: 2020-10-13
+: 2023-02-24
 
 Contributors
 : Steven J Baskauf (lead author) - Vanderbilt University Heard Libraries
@@ -291,7 +356,7 @@ Publisher
 : Biodiversity Information Standards (TDWG)
 
 Abstract
-: Audubon Core uses the terms ac:variant and ac:variantLiteral to provide information about the size, extent, and availability of the Service Access Point of a media item. This controlled vocabulary provides values for those terms.
+: Audiovisual Core uses the terms ac:variant and ac:variantLiteral to provide information about the size, extent, and availability of the Service Access Point of a media item. This controlled vocabulary provides values for those terms.
 
 Citation
-: Audubon Core Maintenance Group. 2020. Controlled Vocabulary for Audubon Core variant: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/variant/2020-10-13>
+: Audiovisual Core Maintenance Group. 2023. Controlled Vocabulary for Audiovisual Core variant: List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/ac/doc/variant/2023-02-24>


### PR DESCRIPTION
The following changes were made:
- change all instances of Audubon Core to Audiovisual Core
- add the two new vocabularies and lists of terms for subjectPart and subjectOrientation
- update version dates and citations to most recent versions
- correct links to actual permanent URLs rather than faking it with the redirect URLs as links.