### PR TITLE
Update standards/tcs/index.md

### DIFF
--- a/standards/tcs/index.md
+++ b/standards/tcs/index.md
@@ -1,7 +1,7 @@
 ---
-title: Taxonomic Concept Transfer Schema (TCS)
+title: Taxon Concept Schema (TCS)
 description: >
-  The TCS schema was conceived to allow the representation of taxonomic concepts as defined in published taxonomic classifications, revisions and databases. As such, it specifies the structure for XML documents to be used for the transfer of defined concepts. Valid transfer documents may either explicitly detail the defining components of taxon concepts, transfer GUIDs referring to defined taxon concepts (if and when these are available) or a mixture of the two.
+  The TCS schema was conceived to allow the representation of taxon concepts as defined in published taxonomic classifications, revisions and databases. As such, it specifies the structure for XML documents to be used for the transfer of defined concepts. Valid transfer documents may either explicitly detail the defining components of taxon concepts, transfer GUIDs referring to defined taxon concepts (if and when these are available) or a mixture of the two.
 background:
   img: https://images.unsplash.com/photo-1502912143929-50c8a1ce1f69
   by: Fancycrave
@@ -13,7 +13,7 @@ toc: true
 ## Header section
 
 Title
-: Taxonomic Concept Transfer Schema (TCS)
+: Taxon Concept Schema (TCS)
 
 Permanent IRI (for citations and links)
 : <http://www.tdwg.org/standards/117>
@@ -38,7 +38,7 @@ Citation
 
 ## Maintenance group
 
-TCS is maintained by the [Taxonomic Names and Concepts Interest Group](/community/tnc/), which has sponsored a Task Group to update TCS to make it compliant with the Standards Documentation Specification and to move it into the Current Standard category.
+TCS is maintained by the [Taxon Concept Schema Maintenance Group](/community/tnc/), which has sponsored a Task Group to update TCS to make it compliant with the Standards Documentation Specification and to move it into the Current Standard category.
 
 ## Parts of the standard
 


### PR DESCRIPTION
- corrected title from 'Taxonomic Concept Transfer Schema' to 'Taxon Concept Schema'; both names were used on the page
- updated name of the TNC to 'Taxon Concept Schema Maintenance Group' (in accordance with the TNC page); only in current context: I left the old names in the citations (obviously)
- changed single instance of 'taxonomic concept' to 'taxon concept', so the term is used consistently