### PR TITLE
Correct incorrect number of standards documents

### DIFF
--- a/standards/dwc/index.md
+++ b/standards/dwc/index.md
@@ -81,7 +81,7 @@ What is not in scope?
 
 ## Parts of the standard
 
-This standard is comprised of 5 vocabularies and 11 documents.
+This standard is comprised of 5 vocabularies and 10 documents.
 
 Vocabularies:
 


### PR DESCRIPTION
If you count the list below, there are only 10