### PR TITLE
Add Kate Ingenloff as core member representing Humboldt Extension

### DIFF
--- a/community/dwc/index.md
+++ b/community/dwc/index.md
@@ -21,6 +21,7 @@ toc: true
 - Tim Robertson - Global Biodiversity Information Facility (GBIF), Denmark
 - Steven Baskauf - Vanderbilt University Heard Libraries, USA
 - Paula Zermoglio - VertNet, USA
+- Kate Ingenloff - Global Biodiversity Information Facility (GBIF), Denmark
 
 ## Motivation
 


### PR DESCRIPTION
Kate is joining the DwC Maintenance Group with a focus on the Humboldt Extension