### PR TITLE
Make notations about task groups that are no longer active.

### DIFF
--- a/community/bdq/tg-3/index.md
+++ b/community/bdq/tg-3/index.md
@@ -12,6 +12,8 @@ Miles Nicholls
 
 ## Motivation
 
+**NOTE: this Task Group has completed its work and is no longer active.**
+
 - Other than data availability, 'Data Quality' is probably the most significant issue for users of biodiversity data and this is specially so for the research community.
 - This Task Group is reviewing practical, real world uses relating to 'data quality' with a goal to provide best current practice.
 - If a list of practical data quality use cases can be provided to users of biodiversity records, then greater use and more appropriate use could be made of biodiversity data. Data providers and particularly aggregators such as GBIF and its nodes would have increased credibility with the user communities and be able to provide more effective examples of assessments of fitness for use.
@@ -28,6 +30,8 @@ A set of use cases that are in use by agencies and user communities to select re
 - Contact, via the task group participants, other government and conservation agencies and user communities to establish and document use cases where they assess data fitness for use and the data, dimensions and thresholds required.
 
 ## Becoming involved
+
+**NOTE: this Task Group has completed its work and is no longer active.**
 
 This Task Group would welcome anyone who has a practical interest in data quality and/or has experience with selecting data sets and records for specific purposes.
 

--- a/community/dwc/index.md
+++ b/community/dwc/index.md
@@ -19,9 +19,10 @@ toc: true
 - Peter Desmet - Research Institute for Nature and Forest (INBO), Belgium
 - Markus Döring - Global Biodiversity Information Facility (GBIF), Denmark
 - Tim Robertson - Global Biodiversity Information Facility (GBIF), Denmark
-- Steven Baskauf - Vanderbilt University Heard Libraries, USA
+- [Steven Baskauf](mailto:steve.baskauf@vanderbilt.edu) - Vanderbilt University Heard Libraries, USA
 - Paula Zermoglio - VertNet, USA
 - Kate Ingenloff - Global Biodiversity Information Facility (GBIF), Denmark
+- [Quentin Groom](mailto:quentin.groom@plantentuinmeise.be) - Meise Botanic Garden, Belgium
 
 ## Motivation
 

--- a/community/esp/chrono/index.md
+++ b/community/esp/chrono/index.md
@@ -25,6 +25,8 @@ toc: true
 
 ## Motivation
 
+**NOTE: this Task Group has completed its work and is no longer active.**
+
 The Task Group is required in order to produce a new TDWG standard vocabulary. The new vocabulary to be produced by the Task Group is an extension to Darwin Core for chronometric age information. Chronometric age information is not covered by terms in Darwin Core, and is important in paleontology, zooarchaeology, and archaeobotany.
 
 ## Goals, outputs and outcomes
@@ -42,6 +44,8 @@ The Task Group is required in order to produce a new TDWG standard vocabulary. T
 - The outputs will follow the TDWG Standards Documentation Standard (SDS) and will be reviewed as required processes by the [TDWG By-laws](/about/process/) for the ratification of standards.
 
 ## Becoming involved
+
+**NOTE: this Task Group has completed its work and is no longer active.**
 
 Interested parties are invited to watch and contribute to the GitHub repository.
 

--- a/community/osr/how-did-it-die/index.md
+++ b/community/osr/how-did-it-die/index.md
@@ -1,3 +1,4 @@
+
 ---
 title: How Did It Die?
 description: >
@@ -17,6 +18,8 @@ toc: true
 - Libby Ellwood - Natural History Museum of Los Angeles, CA, USA
 
 ## Motivation
+
+**NOTE: this Task Group has completed its work and is no longer active.**
 
 There is a requirement that species records express whether the organism was dead or alive at the time of the observation or collection, and what the cause of any death was. Currently no such explicit terms exist in Darwin Core.
 
@@ -73,6 +76,8 @@ The scope of the terms, their names and vocabularies will be discussed within th
 - Submit proposals to TDWG’s journal BISS.
 
 ## Becoming involved
+
+**NOTE: this Task Group has completed its work and is no longer active.**
 
 This Task Group welcomes anyone who has a practical interest in recording and reporting biodiversity occurrence or collection records. The group may need support for the development of machine-readable vocabularies.
 

--- a/community/osr/humboldt-extension/index.md
+++ b/community/osr/humboldt-extension/index.md
@@ -36,6 +36,8 @@ toc: true
 
 ## Motivation
 
+**NOTE: this Task Group has completed its work. There may be future task groups formed to continue development of the extension -- contact the convener if you are interested in being involved.**
+
 Species inventories are routinely performed and offer particular value for characterizing biodiversity and its change. However, reporting standards allowing these inventories to be re‐used, compared to one another, and further integrated with other sources of biodiversity data are lacking, impeding their broadest utility. The Darwin Core standard currently allows sharing some of the information related to inventories, i.e., terms samplingProtocol, sampleSizeValue, sampleSizeUnit, samplingEffort. However, it still presents a limited ability to express detailed reporting of scope (spatial, temporal, taxonomic, and environmental), as well as a whole suite of commonly measured aspects of inventory sampling processes (e.g., direct or inferred measures of sampling effort).
 
 These limitations could be overcome by formalizing the Humboldt Core, a framework developed to deal specifically with this kind of data (Guralnick et al. 2018), and which is currently implemented in Map of Life (<https://mol.org/humboldtcore/>). While originally planned as a TDWG standard, ratification was not pursued until now. Broader implementation throughout the community has been hampered by a needed review of how to best integrate its terms with existing standards and implementation schemas. The natural space for the development of such a standard within TDWG is the Observations & Specimens Interest Group. While the purpose of this group is “to explore concepts and methods of biodiversity data description, integration and transfer that fully integrate specimen and observational data into existing data exchange schemas”, they have not yet tackled inventory data, which constitute an interesting mix of Events, Occurrences, and Taxon "checklists".
@@ -78,6 +80,8 @@ We will work closely with GBIF staff to coordinate wider implementation and use 
 All development will be done and progress tracked in the Humboldt Core GitHub repository from TDWG GitHub organization.
 
 ## Becoming involved
+
+**NOTE: this Task Group has completed its work. There may be future task groups formed to continue development of the extension -- contact the convener if you are interested in being involved.**
 
 Individuals having an interest in this work should contact the convener and are invited to watch and contribute via the [Humboldt Core GitHub repository](https://github.com/tdwg/hc).
 

--- a/community/osr/index.md
+++ b/community/osr/index.md
@@ -19,18 +19,19 @@ list:
 
 ## Convenor
 
-- [Quentin Groom](mailto:quentin.groom@plantentuinmeise.be) - Meise Botanic Garden, Belgium
+- Quentin Groom - Meise Botanic Garden, Belgium (now member of the Darwin Core Maintenance Group)
 
 Former convenor: Steve Kellin
 
 ## Summary
 
+**NOTE: The Observations & Specimens Interest Group has been closed.** In the future, task groups will be sponsored by the Maintenance Group that will manage the ratification of the task groups' deliverables. Those maintenance groups will generally be the Darwin Core Maintenance Group or the ABCD Maintenance Group for tasks related to observations and specimens. 
+
 Most primary biodiversity data is based on observational data, which consists of observer-derived measurements of organisms in the environment, or specimens collected in the environment and stored within Natural History collections. There is sufficient overlap in the information stored in observational data and specimen records to allow existing data standards to integrate these data types. However, specific data types have unique requirements that need to be addressed. The purpose of this Interest Group is to explore concepts and methods of biodiversity data description, integration and transfer that fully integrate specimen and observational data into existing data exchange schemas.
 
 ## Becoming involved
 
-- Anyone with and interest in organizing observational and specimen data can be involved.
-- Contact [Quentin Groom](mailto:quentin.groom@plantentuinmeise.be)
+- No longer in operation
 
 ## Resources
 
@@ -41,5 +42,7 @@ Most primary biodiversity data is based on observational data, which consists of
 - [OSR How Did It Die](https://www.tdwg.org/community/osr/how-did-it-die/)
 
 ## Task groups
+
+The How Did it Die?, Humboldt Extension, and Material Sample Task Groups have completed the tasks originally specified in their charters. The Plant Phenology Task Group is still active, but is now listed under the [Darwin Core Maintenance Group](https://www.tdwg.org/community/dwc/).
 
 <!-- list will be inserted below content -->

--- a/community/osr/material-sample/index.md
+++ b/community/osr/material-sample/index.md
@@ -36,6 +36,8 @@ toc: true
 
 ## Motivation
 
+**NOTE: this Task Group has completed its work and is no longer active.**
+
 Members of the Arctos Working Group feel that [MaterialSample](https://dwc.tdwg.org/terms/#materialsample) and [PreservedSpecimen](https://dwc.tdwg.org/terms/#preservedspecimen) are currently interchangeable. See [ArctosDB/arctos#2432](https://github.com/ArctosDB/arctos/issues/2432) for further discussion. The Global Genome Biodiversity Network ([GGBN](https://www.ggbn.org/ggbn_portal/)) community is using the Occurrence class currently as a MaterialSample class, as there is no alternative available right now if we want to publish information to aggregators such as the Global Biodiversity Information Facility ([GBIF](https://www.gbif.org)). It became apparent in the [TDWG issue](https://github.com/tdwg/dwc/issues/314) about this change request that other issues pertaining to the representation of settings and events in which material samples occur need clarification too. There are terms in the Occurrence class that feel unnatural there, and the distinction between Darwin Core terms that are related to physical objects[^1] feels arbitrary.
 
 The purpose of this task group is to investigate and make recommendations on current shortcomings in the capacity to share, re-use, compare, and relate physical objects to one another and to other concepts, and further integrate with other sources of biodiversity data.
@@ -80,6 +82,8 @@ We intend to document the rationale for creating revised definitions, particular
 The task group will develop term definitions using GitHub issues in the [GitHub repository](https://github.com/tdwg/material-sample) from TDWG GitHub organization. Monthly meetings in a virtual platform will ensure that the task group remains active and working on the deliverables. Specific examples of the ways these terms are used by collection management systems will inform the definitions and recommendations. Members of related Interest and Task Groups are core members of this Task Group to ensure different use cases are addressed.
 
 ## Becoming involved
+
+**NOTE: this Task Group has completed its work and is no longer active.**
 
 Individuals having an interest in this work should contact the conveners, and are invited to watch and contribute via the [GitHub repository](https://github.com/tdwg/material-sample).
 


### PR DESCRIPTION
@stanblum I have recovered the changes that I made earlier. Since these only involve Markdown text and not the navigation structure, I think they can be safely merged without causing the failure to build that we saw before. 