### PR TITLE
Implementation of parts of the Proposal for Categorizing standards

### DIFF
--- a/standards/externally-managed/index.md
+++ b/standards/externally-managed/index.md
@@ -1,0 +1,32 @@
+---
+title: Externally-managed standards
+description: >
+  Some early TDWG standards are now managed by other organizations. This page provides links to those standards.
+background:
+  img: https://images.unsplash.com/photo-1518709766631-a6a7f45921c3
+  by: sutirta budiman
+  href: https://unsplash.com/photos/PdiOj8kRy28
+toc: true
+---
+
+The standards listed on this page were ratified as TDWG standards prior to the adoption of the [current standards development process](/about/process/) in 2006. Although TDWG no longer has any role in maintaining them, TDWG still recommends their use, even though they may not qualify as Current Standards under the present-day documentation and maintenance criteria.
+
+## Authors of Plant Names
+
+Maintained as part of [The International Plant Names Index (IPNI)](https://www.ipni.org/). [Landing page for standard](/standards/plant-names-authors/)
+
+## Botanico-Periodicum-Huntianum and Botanico-Periodicum-Huntianum/Supplementum
+
+Maintained by the [Hunt Institute for Botanical Documentation](http://huntbotanical.org/databases/show.php?1).  [Landing page for BPH standard](/standards/bph/). [Landing page for BPH Supplementum standard](/standards/bph-supplementum/)
+
+## DEscription Language for TAxonomy (DELTA). 
+
+Maintained by [its authors](https://www.delta-intkey.com/).  [Landing page for standard](/standards/delta/)
+
+## Index Herbariorum
+
+Online version maintained by the [New York Botanical Gardens](https://sweetgum.nybg.org/science/ih/).  [Landing page for standard](/standards/ih/)
+
+## Taxonomic Literature, Edition 2 and its Supplements
+
+Online version maintained by the [Smithsonian Institution](https://www.sil.si.edu/DigitalCollections/tl-2/index.cfm).  [Landing page for standard](/standards/tl-2/)

--- a/standards/status-and-categories/index.md
+++ b/standards/status-and-categories/index.md
@@ -24,10 +24,10 @@ Standards that were ratified prior to 2005 and that are not currently being prom
 
 ### Retired Standard
 
-Standards that have been ratified by TDWG in the past but that are no longer recommended.
+Standards that have been ratified by TDWG in the past but that are no longer recommended. A standard may be no longer recommended if there is a Current Standard that has superseded it.
 
 {:id="category"}
-## Categories of TDWG standards
+## Categories of TDWG standards documents
 
 ### Technical Specification (TS)
 
@@ -40,7 +40,3 @@ Specifies how, and under what circumstances, one or more TS (from TDWG or other 
 ### Best Current Practice (BCP)
 
 A description of standardized practices and the results of community deliberations. A BCP document is a vehicle by which the biodiversity information community can define and ratify the community's best current thinking on a statement of principle or on what is believed to be the best way to perform some operations or TDWG process function. For more information, see RFC 2026.
-
-### Data Standard (DS)
-
-Specifies valid values in controlled vocabularies.


### PR DESCRIPTION
@peterdesmet @stanblum 

In retrospect, I probably should have done this in a branch rather than the master. I'm getting a little over my head in terms of doing a pull request from a fork. But I think it would be relatively harmless to go ahead and merge this. 

The commit https://github.com/tdwg/website/commit/bfd64e8ecf30729eedd1f862e800031e76eaa8f7 makes some wording changes in the [Standards Status and Categories page](https://www.tdwg.org/standards/status-and-categories/) as described in [Proposals 1 and 4 of the Proposal for Categorizing Standards](https://docs.google.com/document/d/1qg8JKHmsEzBWcSo2Ip0ga6PcS4vJjTt2-r-XJALjk5E/edit) that was approved by the Exec. That should be fine to implement.

The commit https://github.com/tdwg/website/commit/bfd64e8ecf30729eedd1f862e800031e76eaa8f7 creates the new page that was described in Proposal 2 of the Proposal for Categorizing standards. I think it is relatively harmless to create this new page, although it isn't linked anywhere and I don't know that the styling is what we want (in terms of a table of contents, spash image, etc). I also don't know if it will automatically get picked up in some menu somewhere. 

If we go ahead and create it, it should also be properly linked from the Standards menu as described in the proposal and also probably from a regular hyperlink from the (current) Standards page. But that would require messing with the navigation structure, since currently "Standards" is just a link and not a dropdown. Perhaps @peterdesmet can just fix that at the same time he works on the other navigation issue from my last pull request.

The other thing that I did not do was to implement Proposal 3, which involves dividing the standards on the main standards page into "Actively maintained" and "Not under active maintenance" (in addition to removing the standards that were put onto the new page as part of Proposal 2). I'm not going to touch this since I don't really understand what is going on with the generation of the standards page. @peterdesmet this one is probably for you to handle.
