### PR TITLE
Add missing core members

### DIFF
--- a/community/ac/index.md
+++ b/community/ac/index.md
@@ -20,6 +20,8 @@ list:
 
 ## Core members
 
+- Vijay Barve - Natural History Museum of Los Angeles, CA, USA
+- Steve Baskauf - Vanderbilt University Heard Libraries (retired), Nashville, TN, USA
 - Douglas Boyer - Department of Evolutionary Anthropology, Duke University, NC, USA
 - Niels Klazenga - Royal Botanic Gardens Victoria, Australia
 - Rebecca Snyder - Smithsonian Institution, National Museum of Natural History, Washington DC, USA


### PR DESCRIPTION
Vijay was added as a core member some time ago, but never got added to the list here. Not sure how I got omitted -- perhaps when I was no longer the convener I didn't get moved down to the core members?