### PR TITLE
Update DwC MG convener information

### DIFF
--- a/community/dwc/index.md
+++ b/community/dwc/index.md
@@ -22,11 +22,11 @@ list:
 
 ## Convener
 
-- [John Wieczorek](mailto:gtuco.btuco@gmail.com) - Rauthiflor LLC; USA, Argentina
+- [Steven Baskauf](mailto:steve.baskauf@gmail.com) - Vanderbilt University Heard Libraries (retired); USA
 
 ## Core members
 
-- [Steven Baskauf](mailto:steve.baskauf@gmail.com) - Vanderbilt University Heard Libraries (retired); USA
+- [John Wieczorek](mailto:gtuco.btuco@gmail.com) - Rauthiflor LLC; USA, Argentina
 - Peter Desmet - Research Institute for Nature and Forest (INBO); Belgium
 - Markus Döring - Global Biodiversity Information Facility (GBIF); Denmark
 - [Quentin Groom](mailto:quentin.groom@plantentuinmeise.be) - Meise Botanic Garden; Belgium


### PR DESCRIPTION
During the review, public comment period, and ratification of DwC-DP, Steve will be replacing John in the convener role to avoid any appearance of conflict of interest on John's part.