### PR TITLE
Remove Twitter, add Bluesky and LinkedIn

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,10 @@ repository: tdwg/website
 # SOCIAL PROFILES
 social:
   email: secretary@tdwg.org
-  twitter: tdwg
+  bluesky: tdwg.org
+  linkedin: https://www.linkedin.com/company/tdwg/
+  facebook: https://www.facebook.com/groups/326780777736/
   github: tdwg
-  facebook: https://www.facebook.com/groups/326780777736
 
 # THEME SETTINGS
 theme: minima


### PR DESCRIPTION
This updates the footer of https://tdwg.org

Before:

<img width="384" height="116" alt="Screenshot 2025-09-10 at 17 30 22" src="https://github.com/user-attachments/assets/8504e7a9-a797-4462-8654-054d67470847" />

After:

<img width="398" height="127" alt="Screenshot 2025-09-10 at 17 30 30" src="https://github.com/user-attachments/assets/205b5f44-492f-465d-bf50-507df396d4f2" />
