### PR TITLE
Add Jocelyn Troplett to AC MG

### DIFF
--- a/community/ac/index.md
+++ b/community/ac/index.md
@@ -26,6 +26,7 @@ list:
 - Niels Klazenga - Royal Botanic Gardens Victoria, Australia
 - Rebecca Snyder - Smithsonian Institution, National Museum of Natural History, Washington DC, USA
 - Dan Stowell - Tilburg University and Naturalis Biodiversity Centre, Netherlands
+- Jocelyn Triplett - Duke University, MorphoSource.org
 - Kate Webbink - Field Museum of Natural History, Chicago, IL, USA
 
 ## Motivation


### PR DESCRIPTION
Jocelyn had been a member of the Audiovisual Core Maintenance Group for several months and is listed in the AC [Github repo](https://github.com/tdwg/ac) but has not yet been added to the AC MG community page.