### PR TITLE
PR for additional info from gbif.no for Olso 2026 conf

### DIFF
--- a/conferences/2026/index.md
+++ b/conferences/2026/index.md
@@ -42,6 +42,7 @@ _"Research and Robot-ready Biodiversity Data Standards"_
 
 ### Quick links
 
+- [Local organiser homepage (GBIF Norway)](https://www.gbif.no/events/2026/2026-09-tdwg-in-oslo.html){:target="_blank"}
 - [Call for Sessions](./call-for-sessions/)
 - [Instructions for Session Proposals](./session-instructions/)
 - [Conference event schedule](#conference-event-schedule)


### PR DESCRIPTION
Updates to the TDWG 2026 conference homepage with missing content from the gbif.no event page, and added a link to https://www.gbif.no/events/2026/2026-09-tdwg-in-oslo.html

- Consolidated and formatted additional conference details into the main page:
      - quick links
      - expanded schedule/venue details
      - local transport section
      - hotels section
      - places to see in Oslo
  - Kept existing core content and links, while reducing duplication.
  - Updated the page timestamp to Last updated 6 March 2026.
  - Added image references using conference convention:
      - https://static.tdwg.org/conferences/2026/images/... - IMPORTANT NOTE: images have not yet been uploaded/added

